### PR TITLE
Update dependencies and migrate to biome

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+    "vcs": {
+        "enabled": true,
+        "clientKind": "git",
+        "useIgnoreFile": true
+    },
+    "files": {
+        "ignoreUnknown": false,
+        "ignore": []
+    },
+    "formatter": {
+        "enabled": true,
+        "indentStyle": "space",
+        "indentWidth": 4
+    },
+    "organizeImports": {
+        "enabled": true
+    },
+    "linter": {
+        "enabled": true,
+        "rules": {
+            "recommended": true,
+            "complexity": {
+                "recommended": true,
+                "noForEach": "off"
+            }
+        }
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "single"
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,43 +1,34 @@
 {
     "name": "@runejs/store",
-    "version": "1.0.0-beta.1",
+    "version": "1.0.0-beta.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@runejs/store",
-            "version": "1.0.0-beta.1",
+            "version": "1.0.0-beta.2",
             "license": "GPL-3.0",
             "dependencies": {
-                "@runejs/common": "2.0.2-beta.2",
-                "graceful-fs": "^4.2.0",
-                "json5": "^2.2.0",
-                "reflect-metadata": "^0.1.13",
-                "sqlite": "^4.0.25",
-                "tslib": "^2.3.1",
-                "typeorm": "^0.2.44",
-                "yargs": "^17.3.1"
+                "@runejs/common": "2.0.2-beta.3",
+                "better-sqlite3": "^11.8.1",
+                "json5": "^2.2.3",
+                "tslib": ">=2.8.1",
+                "typeorm": "^0.2.45",
+                "yargs": "^17.7.2"
             },
             "devDependencies": {
-                "@runejs/eslint-config": "^1.1.0",
-                "@types/graceful-fs": "^4.1.5",
-                "@types/node": "^16.11.26",
-                "@types/yargs": "^17.0.9",
-                "@typescript-eslint/eslint-plugin": "^5.14.0",
-                "@typescript-eslint/parser": "^5.14.0",
-                "better-sqlite3": "^7.5.0",
+                "@biomejs/biome": "1.9.4",
+                "@types/node": "^22.10.7",
+                "@types/yargs": "^17.0.33",
                 "copyfiles": "^2.4.1",
-                "eslint": "^8.11.0",
-                "rimraf": "^3.0.2",
-                "source-map-support": "^0.5.21",
-                "ts-node-dev": "^1.1.8",
-                "typescript": "^4.5.5"
+                "rimraf": "6.0.1",
+                "ts-node": "^10.9.2",
+                "typescript": "^5.7.3"
             },
             "peerDependencies": {
-                "@runejs/common": "2.0.2-beta.2",
-                "graceful-fs": ">=4.2.0",
-                "tslib": ">=2.3.0",
-                "typescript": ">=4.5.0"
+                "@runejs/common": "2.0.2-beta.3",
+                "tslib": ">=2.8.1",
+                "typescript": "^5.7.3"
             }
         },
         "../common/lib": {
@@ -70,42 +61,181 @@
                 "typescript": ">=4.5.0"
             }
         },
-        "node_modules/@eslint/eslintrc": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-            "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+        "node_modules/@biomejs/biome": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+            "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
             "dev": true,
-            "dependencies": {
-                "ajv": "^6.12.4",
-                "debug": "^4.3.2",
-                "espree": "^9.3.1",
-                "globals": "^13.9.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
-                "minimatch": "^3.0.4",
-                "strip-json-comments": "^3.1.1"
+            "hasInstallScript": true,
+            "license": "MIT OR Apache-2.0",
+            "bin": {
+                "biome": "bin/biome"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": ">=14.21.3"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/biome"
+            },
+            "optionalDependencies": {
+                "@biomejs/cli-darwin-arm64": "1.9.4",
+                "@biomejs/cli-darwin-x64": "1.9.4",
+                "@biomejs/cli-linux-arm64": "1.9.4",
+                "@biomejs/cli-linux-arm64-musl": "1.9.4",
+                "@biomejs/cli-linux-x64": "1.9.4",
+                "@biomejs/cli-linux-x64-musl": "1.9.4",
+                "@biomejs/cli-win32-arm64": "1.9.4",
+                "@biomejs/cli-win32-x64": "1.9.4"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
-        "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+        "node_modules/@biomejs/cli-darwin-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+            "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-darwin-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+            "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+            "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-arm64-musl": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+            "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+            "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-x64-musl": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+            "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-win32-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+            "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-win32-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+            "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "argparse": "^2.0.1"
+                "@jridgewell/trace-mapping": "0.3.9"
             },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@hapi/bourne": {
@@ -113,87 +243,98 @@
             "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
             "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
         },
-        "node_modules/@humanwhocodes/config-array": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
             },
             "engines": {
-                "node": ">=10.10.0"
+                "node": ">=12"
             }
         },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true
-        },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
             },
             "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
+                "node": ">=12"
             },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">= 8"
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
         "node_modules/@runejs/common": {
-            "version": "2.0.2-beta.2",
-            "resolved": "https://registry.npmjs.org/@runejs/common/-/common-2.0.2-beta.2.tgz",
-            "integrity": "sha512-Xd9/Ws3ByAdI1R08Ye9fWqlS8SImjQw05Bsw0w46zcGyDx8N6jmeClf9Y/s4Akh9VZQuoAMFg2ANKsRK0MucNw==",
+            "version": "2.0.2-beta.3",
+            "resolved": "https://registry.npmjs.org/@runejs/common/-/common-2.0.2-beta.3.tgz",
+            "integrity": "sha512-IJGJ8ZspbHzqO5EPhWJuXBLfzNewOiGl9HqxrrJGVsCZmagRTekOXik2diWp9h6A99rjuKyOUg84PW3GwHM9TA==",
+            "license": "GPL-3.0",
             "dependencies": {
                 "compressjs": "^1.0.3",
                 "js-yaml": "^3.14.1",
                 "pino": "^6.14.0",
                 "pino-pretty": "^4.8.0",
                 "sonic-boom": "^2.6.0",
-                "tslib": "^2.3.1"
+                "tslib": ">=2.8.1"
             },
             "peerDependencies": {
-                "tslib": ">=2.3.0",
-                "typescript": ">=4.5.0"
-            }
-        },
-        "node_modules/@runejs/eslint-config": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@runejs/eslint-config/-/eslint-config-1.1.0.tgz",
-            "integrity": "sha512-mNfYgw5/ZBnivE2h5MnMohbneHOzW0qyCVrNlhiW2Cn0iYfaAX4YQSlU6xA4oC/vIn/3R3zenJAxBip0Iyt2dg==",
-            "dev": true,
-            "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": ">=5.14.0",
-                "@typescript-eslint/parser": ">=5.14.0",
-                "eslint": ">=8"
+                "tslib": ">=2.8.1"
             }
         },
         "node_modules/@sqltools/formatter": {
@@ -201,44 +342,50 @@
             "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.3.tgz",
             "integrity": "sha512-O3uyB/JbkAEMZaP3YqyHH7TMnex7tWyCbCI4EfJdOCoN6HIhqdJBWTM6aCCiWQ/5f5wxjgU735QAIpJbjDvmzg=="
         },
-        "node_modules/@types/graceful-fs": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
-            "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
             "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
+            "license": "MIT"
         },
-        "node_modules/@types/json-schema": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-            "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-            "dev": true
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "16.11.26",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-            "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
-            "dev": true
-        },
-        "node_modules/@types/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-            "dev": true
-        },
-        "node_modules/@types/strip-json-comments": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-            "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-            "dev": true
+            "version": "22.10.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+            "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.20.0"
+            }
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.9",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.9.tgz",
-            "integrity": "sha512-Ci8+4/DOtkHRylcisKmVMtmVO5g7weUVCKcsu1sJvF1bn0wExTmbHmhFKj7AnEm0de800iovGhdSKzYnzbaHpg==",
+            "version": "17.0.33",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
@@ -254,195 +401,12 @@
             "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
             "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
         },
-        "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
-            "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/type-utils": "5.14.0",
-                "@typescript-eslint/utils": "5.14.0",
-                "debug": "^4.3.2",
-                "functional-red-black-tree": "^1.0.1",
-                "ignore": "^5.1.8",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/parser": "^5.0.0",
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/parser": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
-            "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
-                "debug": "^4.3.2"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
-            "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
-            "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/utils": "5.14.0",
-                "debug": "^4.3.2",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/types": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
-            "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
-            "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0",
-                "debug": "^4.3.2",
-                "globby": "^11.0.4",
-                "is-glob": "^4.0.3",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
-            "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
-            "dev": true,
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
-            "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.14.0",
-                "eslint-visitor-keys": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
         "node_modules/acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -450,29 +414,17 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+        "node_modules/acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
             "dev": true,
-            "peerDependencies": {
-                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "acorn": "^8.11.0"
             },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/amdefine": {
@@ -484,12 +436,16 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "devOptional": true,
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/ansi-styles": {
@@ -508,41 +464,12 @@
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
         },
-        "node_modules/anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-            "dev": true,
-            "dependencies": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/app-root-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
             "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw==",
             "engines": {
                 "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-            "devOptional": true
-        },
-        "node_modules/are-we-there-yet": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-            "devOptional": true,
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
             }
         },
         "node_modules/arg": {
@@ -586,15 +513,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/atomic-sleep": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -628,30 +546,20 @@
             ]
         },
         "node_modules/better-sqlite3": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.5.0.tgz",
-            "integrity": "sha512-6FdG9DoytYGDhLW7VWW1vxjEz7xHkqK6LnaUQYA8d6GHNgZhu9PFX2xwKEEnSBRoT1J4PjTUPeg217ShxNmuPg==",
-            "devOptional": true,
+            "version": "11.8.1",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.8.1.tgz",
+            "integrity": "sha512-9BxNaBkblMjhJW8sMRZxnxVTRgbRmssZW0Oxc1MPBTfiR+WW21e2Mk4qu8CzrcZb1LwPCnFsfDEzq+SNcBU8eg==",
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
                 "bindings": "^1.5.0",
-                "prebuild-install": "^7.0.0"
-            }
-        },
-        "node_modules/binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
+                "prebuild-install": "^7.1.1"
             }
         },
         "node_modules/bindings": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "devOptional": true,
             "dependencies": {
                 "file-uri-to-path": "1.0.0"
             }
@@ -660,7 +568,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "devOptional": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -668,10 +576,10 @@
             }
         },
         "node_modules/bl/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "devOptional": true,
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -690,23 +598,10 @@
                 "concat-map": "0.0.1"
             }
         },
-        "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
-            "dependencies": {
-                "fill-range": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -721,24 +616,10 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
-            }
-        },
-        "node_modules/buffer-from": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
-        },
-        "node_modules/callsites": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/camelcase": {
@@ -813,38 +694,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
-            "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
-            },
-            "engines": {
-                "node": ">= 8.10.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
-            }
-        },
         "node_modules/chownr": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "devOptional": true
+            "license": "ISC"
         },
         "node_modules/cli-highlight": {
             "version": "2.1.11",
@@ -870,14 +724,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-highlight/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "engines": {
                 "node": ">=8"
             }
@@ -949,14 +795,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/cliui/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -979,15 +817,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "devOptional": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/color-convert": {
@@ -1031,12 +860,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
-        "node_modules/console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-            "devOptional": true
-        },
         "node_modules/copyfiles": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
@@ -1060,15 +883,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/copyfiles/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -1131,7 +945,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/create-require": {
             "version": "1.1.1",
@@ -1181,7 +995,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
             "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "devOptional": true,
+            "license": "MIT",
             "dependencies": {
                 "mimic-response": "^3.1.0"
             },
@@ -1196,22 +1010,19 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "devOptional": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0.0"
             }
         },
-        "node_modules/deep-is": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true
-        },
-        "node_modules/delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-            "devOptional": true
+        "node_modules/detect-libc": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -1222,30 +1033,6 @@
                 "node": ">=0.3.1"
             }
         },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/dotenv": {
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
@@ -1254,14 +1041,12 @@
                 "node": ">=10"
             }
         },
-        "node_modules/dynamic-dedupe": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
-            "integrity": "sha1-BuRMIj9eTpTXjvnbI6ZRXOL5YqE=",
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true,
-            "dependencies": {
-                "xtend": "^4.0.0"
-            }
+            "license": "MIT"
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -1292,206 +1077,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/eslint": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
-            "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
-            "dev": true,
-            "dependencies": {
-                "@eslint/eslintrc": "^1.2.1",
-                "@humanwhocodes/config-array": "^0.9.2",
-                "ajv": "^6.10.0",
-                "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
-                "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.1",
-                "esquery": "^1.4.0",
-                "esutils": "^2.0.2",
-                "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^6.0.1",
-                "globals": "^13.6.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "js-yaml": "^4.1.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.0.4",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
-                "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
-            },
-            "bin": {
-                "eslint": "bin/eslint.js"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "dependencies": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "engines": {
-                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=5"
-            }
-        },
-        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/eslint/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/eslint/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
-        "node_modules/eslint/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-            "dev": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/eslint/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/eslint/node_modules/glob-parent": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
-            "dependencies": {
-                "is-glob": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/eslint/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/eslint/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/espree": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-            "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
-            "dev": true,
-            "dependencies": {
-                "acorn": "^8.7.0",
-                "acorn-jsx": "^5.3.1",
-                "eslint-visitor-keys": "^3.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
         "node_modules/esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1504,108 +1089,14 @@
                 "node": ">=4"
             }
         },
-        "node_modules/esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
-            "dependencies": {
-                "estraverse": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/esquery/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/esrecurse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
-            "dependencies": {
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/esrecurse/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/expand-template": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "devOptional": true,
+            "license": "(MIT OR WTFPL)",
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "node_modules/fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
-        },
-        "node_modules/fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
         },
         "node_modules/fast-redact": {
             "version": "3.1.1",
@@ -1620,121 +1111,43 @@
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         },
-        "node_modules/fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-            "dev": true,
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "dev": true,
-            "dependencies": {
-                "flat-cache": "^3.0.4"
-            },
-            "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            }
-        },
         "node_modules/file-uri-to-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "devOptional": true
-        },
-        "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-            "dev": true,
-            "dependencies": {
-                "flatted": "^3.1.0",
-                "rimraf": "^3.0.2"
-            },
-            "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            }
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
         "node_modules/flatstr": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
             "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
         },
-        "node_modules/flatted": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-            "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
-            "dev": true
+        "node_modules/foreground-child": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+            "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "devOptional": true
+            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
-        },
-        "node_modules/functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true
-        },
-        "node_modules/gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "devOptional": true,
-            "dependencies": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
@@ -1747,8 +1160,8 @@
         "node_modules/github-from-package": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-            "devOptional": true
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "license": "MIT"
         },
         "node_modules/glob": {
             "version": "7.1.6",
@@ -1769,74 +1182,10 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/globals": {
-            "version": "13.12.1",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-            "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
-            "dev": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/graceful-fs": {
-            "version": "4.2.9",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-            "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
-        },
         "node_modules/graceful-readlink": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-        },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
         },
         "node_modules/has-flag": {
             "version": "3.0.0",
@@ -1845,12 +1194,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-            "devOptional": true
         },
         "node_modules/highlight.js": {
             "version": "10.7.3",
@@ -1879,40 +1222,6 @@
                 }
             ]
         },
-        "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-            "dev": true,
-            "dependencies": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.19"
-            }
-        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1931,85 +1240,44 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "devOptional": true
-        },
-        "node_modules/is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
-            "dependencies": {
-                "binary-extensions": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-            "dev": true,
-            "dependencies": {
-                "has": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
+            "license": "ISC"
         },
         "node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "devOptional": true,
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
             "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.12.0"
+                "node": ">=8"
             }
         },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
+        },
+        "node_modules/jackspeak": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
+            "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/jmespath": {
             "version": "0.15.0",
@@ -2039,25 +1307,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
-        },
-        "node_modules/json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-            "dev": true
-        },
         "node_modules/json5": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-            "dependencies": {
-                "minimist": "^1.2.5"
-            },
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "license": "MIT",
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -2073,30 +1327,10 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/levn": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
-            "dependencies": {
-                "prelude-ls": "^1.2.1",
-                "type-check": "~0.4.0"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
         "node_modules/lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "devOptional": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -2110,33 +1344,11 @@
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
         },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-            "dev": true,
-            "dependencies": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
         "node_modules/mimic-response": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
             "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "devOptional": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -2160,6 +1372,16 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
             "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -2175,7 +1397,7 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "devOptional": true
+            "license": "MIT"
         },
         "node_modules/mri": {
             "version": "1.1.4",
@@ -2201,22 +1423,16 @@
             }
         },
         "node_modules/napi-build-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "devOptional": true
-        },
-        "node_modules/natural-compare": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+            "license": "MIT"
         },
         "node_modules/node-abi": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.8.0.tgz",
-            "integrity": "sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==",
-            "devOptional": true,
+            "version": "3.73.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.73.0.tgz",
+            "integrity": "sha512-z8iYzQGBu35ZkTQ9mtR8RqugJZ9RCLn8fv3d7LsgDBzOijGQP3RdKTX4LA7LXw03ZhU5z0l4xfhIMgSES31+cg==",
+            "license": "MIT",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -2258,36 +1474,6 @@
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
             "dev": true
         },
-        "node_modules/normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "devOptional": true,
-            "dependencies": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "node_modules/number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "devOptional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2304,34 +1490,12 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-            "dev": true,
-            "dependencies": {
-                "deep-is": "^0.1.3",
-                "fast-levenshtein": "^2.0.6",
-                "levn": "^0.4.1",
-                "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/parent-module": {
+        "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true,
-            "dependencies": {
-                "callsites": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
+            "license": "BlueOak-1.0.0"
         },
         "node_modules/parse5": {
             "version": "5.1.1",
@@ -2368,31 +1532,31 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
-        },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+        "node_modules/path-scurry": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
             "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
             "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.6"
+                "node": "20 || >=22"
             },
             "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+            "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/pino": {
@@ -2462,19 +1626,18 @@
             }
         },
         "node_modules/prebuild-install": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
-            "integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
-            "devOptional": true,
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "license": "MIT",
             "dependencies": {
                 "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
                 "github-from-package": "0.0.0",
                 "minimist": "^1.2.3",
                 "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^1.0.1",
+                "napi-build-utils": "^2.0.0",
                 "node-abi": "^3.3.0",
-                "npmlog": "^4.0.1",
                 "pump": "^3.0.0",
                 "rc": "^1.2.7",
                 "simple-get": "^4.0.0",
@@ -2488,29 +1651,11 @@
                 "node": ">=10"
             }
         },
-        "node_modules/prebuild-install/node_modules/detect-libc": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-            "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
-            "devOptional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/process-warning": {
             "version": "1.0.0",
@@ -2526,35 +1671,6 @@
                 "once": "^1.3.1"
             }
         },
-        "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
         "node_modules/quick-format-unescaped": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -2564,7 +1680,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "devOptional": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -2578,8 +1694,8 @@
         "node_modules/rc/node_modules/strip-json-comments": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "devOptional": true,
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2588,7 +1704,7 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2599,34 +1715,10 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "node_modules/readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
-            "engines": {
-                "node": ">=8.10.0"
-            }
-        },
         "node_modules/reflect-metadata": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
             "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-        },
-        "node_modules/regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -2636,83 +1728,79 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/resolve": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-            "dev": true,
-            "dependencies": {
-                "is-core-module": "^2.8.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/rfdc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
             "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
         },
         "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+            "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "glob": "^7.1.3"
+                "glob": "^11.0.0",
+                "package-json-from-dist": "^1.0.0"
             },
             "bin": {
-                "rimraf": "bin.js"
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+        "node_modules/rimraf/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
+            "license": "MIT",
             "dependencies": {
-                "queue-microtask": "^1.2.2"
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/rimraf/node_modules/glob": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+            "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^4.0.1",
+                "minimatch": "^10.0.0",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/minimatch": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+            "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/safe-buffer": {
@@ -2729,7 +1817,6 @@
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
             "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "devOptional": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -2739,12 +1826,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-            "devOptional": true
         },
         "node_modules/sha.js": {
             "version": "2.4.11",
@@ -2780,36 +1861,22 @@
             }
         },
         "node_modules/signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-            "devOptional": true
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "devOptional": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2824,19 +1891,31 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT"
+        },
+        "node_modules/simple-get": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
                 "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
-            }
-        },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/sonic-boom": {
@@ -2845,25 +1924,6 @@
             "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
             "dependencies": {
                 "atomic-sleep": "^1.0.0"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/source-map-support": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
             }
         },
         "node_modules/split2": {
@@ -2892,11 +1952,6 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
-        "node_modules/sqlite": {
-            "version": "4.0.25",
-            "resolved": "https://registry.npmjs.org/sqlite/-/sqlite-4.0.25.tgz",
-            "integrity": "sha512-gqCEcLF8FOTeW/na3SRYWLQkw2jZXgVj1DdgRJbm0jvrhnUgBIuNDUUm649AnBNDNHhI5XskwT8dvc8vearRLQ=="
-        },
         "node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -2906,38 +1961,107 @@
             }
         },
         "node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "devOptional": true,
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
             },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "devOptional": true,
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "^6.0.1"
             },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
-        "node_modules/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/strip-json-comments": {
@@ -2962,23 +2086,11 @@
                 "node": ">=4"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "devOptional": true,
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+            "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+            "license": "MIT",
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -2990,7 +2102,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "devOptional": true,
+            "license": "MIT",
             "dependencies": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -3003,10 +2115,10 @@
             }
         },
         "node_modules/tar-stream/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "devOptional": true,
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -3015,12 +2127,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
         },
         "node_modules/thenify": {
             "version": "3.3.1",
@@ -3051,151 +2157,61 @@
                 "xtend": "~4.0.1"
             }
         },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+        "node_modules/ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "node_modules/tree-kill": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-            "dev": true,
-            "bin": {
-                "tree-kill": "cli.js"
-            }
-        },
-        "node_modules/ts-node-dev": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-            "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
-            "dev": true,
-            "dependencies": {
-                "chokidar": "^3.5.1",
-                "dynamic-dedupe": "^0.3.0",
-                "minimist": "^1.2.5",
-                "mkdirp": "^1.0.4",
-                "resolve": "^1.0.0",
-                "rimraf": "^2.6.1",
-                "source-map-support": "^0.5.12",
-                "tree-kill": "^1.2.2",
-                "ts-node": "^9.0.0",
-                "tsconfig": "^7.0.0"
-            },
-            "bin": {
-                "ts-node-dev": "lib/bin.js",
-                "tsnd": "lib/bin.js"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "*",
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ts-node-dev/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/ts-node-dev/node_modules/ts-node": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-            "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-            "dev": true,
-            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
                 "arg": "^4.1.0",
                 "create-require": "^1.1.0",
                 "diff": "^4.0.1",
                 "make-error": "^1.1.1",
-                "source-map-support": "^0.5.17",
+                "v8-compile-cache-lib": "^3.0.1",
                 "yn": "3.1.1"
             },
             "bin": {
                 "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
                 "ts-node-script": "dist/bin-script.js",
                 "ts-node-transpile-only": "dist/bin-transpile.js",
                 "ts-script": "dist/bin-script-deprecated.js"
             },
-            "engines": {
-                "node": ">=10.0.0"
-            },
             "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
                 "typescript": ">=2.7"
-            }
-        },
-        "node_modules/tsconfig": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-            "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-            "dev": true,
-            "dependencies": {
-                "@types/strip-bom": "^3.0.0",
-                "@types/strip-json-comments": "0.0.30",
-                "strip-bom": "^3.0.0",
-                "strip-json-comments": "^2.0.0"
-            }
-        },
-        "node_modules/tsconfig/node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
             }
         },
         "node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "node_modules/tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^1.8.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            },
-            "peerDependencies": {
-                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-            }
-        },
-        "node_modules/tsutils/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "devOptional": true,
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -3203,34 +2219,11 @@
                 "node": "*"
             }
         },
-        "node_modules/type-check": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
-            "dependencies": {
-                "prelude-ls": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/typeorm": {
-            "version": "0.2.44",
-            "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.44.tgz",
-            "integrity": "sha512-yFyb9Ts73vGaS/O06TvLpzvT5U/ngO31GeciNc0eoH7P1QcG8kVZdOy9FHJqkTeDmIljMRgWjbYUoMw53ZY7Xw==",
+            "version": "0.2.45",
+            "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
+            "integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
+            "license": "MIT",
             "dependencies": {
                 "@sqltools/formatter": "^1.2.2",
                 "app-root-path": "^3.0.0",
@@ -3361,16 +2354,25 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/untildify": {
             "version": "4.0.0",
@@ -3379,15 +2381,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "dependencies": {
-                "punycode": "^2.1.0"
             }
         },
         "node_modules/util-deprecate": {
@@ -3403,11 +2396,12 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/v8-compile-cache": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-            "dev": true
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -3424,24 +2418,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "devOptional": true,
-            "dependencies": {
-                "string-width": "^1.0.2 || 2"
-            }
-        },
-        "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -3456,6 +2432,99 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
@@ -3495,14 +2564,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/wrap-ansi/node_modules/string-width": {
             "version": "4.2.3",
@@ -3573,30 +2634,31 @@
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "devOptional": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yargs": {
-            "version": "17.3.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-            "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "license": "MIT",
             "dependencies": {
-                "cliui": "^7.0.2",
+                "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
                 "string-width": "^4.2.3",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^21.0.0"
+                "yargs-parser": "^21.1.1"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/yargs-parser": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-            "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
@@ -3609,12 +2671,18 @@
                 "node": ">=8"
             }
         },
-        "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+        "node_modules/yargs/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
             }
         },
         "node_modules/yargs/node_modules/string-width": {
@@ -3666,38 +2734,85 @@
         }
     },
     "dependencies": {
-        "@eslint/eslintrc": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-            "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+        "@biomejs/biome": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+            "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
             "dev": true,
             "requires": {
-                "ajv": "^6.12.4",
-                "debug": "^4.3.2",
-                "espree": "^9.3.1",
-                "globals": "^13.9.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
-                "minimatch": "^3.0.4",
-                "strip-json-comments": "^3.1.1"
-            },
-            "dependencies": {
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
-                },
-                "js-yaml": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^2.0.1"
-                    }
-                }
+                "@biomejs/cli-darwin-arm64": "1.9.4",
+                "@biomejs/cli-darwin-x64": "1.9.4",
+                "@biomejs/cli-linux-arm64": "1.9.4",
+                "@biomejs/cli-linux-arm64-musl": "1.9.4",
+                "@biomejs/cli-linux-x64": "1.9.4",
+                "@biomejs/cli-linux-x64-musl": "1.9.4",
+                "@biomejs/cli-win32-arm64": "1.9.4",
+                "@biomejs/cli-win32-x64": "1.9.4"
+            }
+        },
+        "@biomejs/cli-darwin-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+            "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-darwin-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+            "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+            "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-arm64-musl": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+            "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+            "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-x64-musl": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+            "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-win32-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+            "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-win32-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+            "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+            "dev": true,
+            "optional": true
+        },
+        "@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "0.3.9"
             }
         },
         "@hapi/bourne": {
@@ -3705,111 +2820,116 @@
             "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
             "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
         },
-        "@humanwhocodes/config-array": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+        "@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
             "requires": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+                    "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+                    "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^6.1.0",
+                        "string-width": "^5.0.1",
+                        "strip-ansi": "^7.0.1"
+                    }
+                }
             }
         },
-        "@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+        "@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true
         },
-        "@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            }
-        },
-        "@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "dev": true
         },
-        "@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
             "dev": true,
             "requires": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
         "@runejs/common": {
-            "version": "2.0.2-beta.2",
-            "resolved": "https://registry.npmjs.org/@runejs/common/-/common-2.0.2-beta.2.tgz",
-            "integrity": "sha512-Xd9/Ws3ByAdI1R08Ye9fWqlS8SImjQw05Bsw0w46zcGyDx8N6jmeClf9Y/s4Akh9VZQuoAMFg2ANKsRK0MucNw==",
+            "version": "2.0.2-beta.3",
+            "resolved": "https://registry.npmjs.org/@runejs/common/-/common-2.0.2-beta.3.tgz",
+            "integrity": "sha512-IJGJ8ZspbHzqO5EPhWJuXBLfzNewOiGl9HqxrrJGVsCZmagRTekOXik2diWp9h6A99rjuKyOUg84PW3GwHM9TA==",
             "requires": {
                 "compressjs": "^1.0.3",
                 "js-yaml": "^3.14.1",
                 "pino": "^6.14.0",
                 "pino-pretty": "^4.8.0",
                 "sonic-boom": "^2.6.0",
-                "tslib": "^2.3.1"
+                "tslib": ">=2.8.1"
             }
-        },
-        "@runejs/eslint-config": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@runejs/eslint-config/-/eslint-config-1.1.0.tgz",
-            "integrity": "sha512-mNfYgw5/ZBnivE2h5MnMohbneHOzW0qyCVrNlhiW2Cn0iYfaAX4YQSlU6xA4oC/vIn/3R3zenJAxBip0Iyt2dg==",
-            "dev": true,
-            "requires": {}
         },
         "@sqltools/formatter": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.3.tgz",
             "integrity": "sha512-O3uyB/JbkAEMZaP3YqyHH7TMnex7tWyCbCI4EfJdOCoN6HIhqdJBWTM6aCCiWQ/5f5wxjgU735QAIpJbjDvmzg=="
         },
-        "@types/graceful-fs": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
-            "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
+        "@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+            "dev": true
         },
-        "@types/json-schema": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-            "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+        "@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true
         },
         "@types/node": {
-            "version": "16.11.26",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-            "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
-            "dev": true
-        },
-        "@types/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-            "dev": true
-        },
-        "@types/strip-json-comments": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-            "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-            "dev": true
+            "version": "22.10.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+            "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~6.20.0"
+            }
         },
         "@types/yargs": {
-            "version": "17.0.9",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.9.tgz",
-            "integrity": "sha512-Ci8+4/DOtkHRylcisKmVMtmVO5g7weUVCKcsu1sJvF1bn0wExTmbHmhFKj7AnEm0de800iovGhdSKzYnzbaHpg==",
+            "version": "17.0.33",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
@@ -3826,124 +2946,19 @@
             "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
             "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
         },
-        "@typescript-eslint/eslint-plugin": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
-            "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/type-utils": "5.14.0",
-                "@typescript-eslint/utils": "5.14.0",
-                "debug": "^4.3.2",
-                "functional-red-black-tree": "^1.0.1",
-                "ignore": "^5.1.8",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/parser": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
-            "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
-                "debug": "^4.3.2"
-            }
-        },
-        "@typescript-eslint/scope-manager": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
-            "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0"
-            }
-        },
-        "@typescript-eslint/type-utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
-            "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/utils": "5.14.0",
-                "debug": "^4.3.2",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/types": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
-            "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
-            "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
-            "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0",
-                "debug": "^4.3.2",
-                "globby": "^11.0.4",
-                "is-glob": "^4.0.3",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
-            "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
-            "dev": true,
-            "requires": {
-                "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0"
-            }
-        },
-        "@typescript-eslint/visitor-keys": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
-            "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.14.0",
-                "eslint-visitor-keys": "^3.0.0"
-            }
-        },
         "acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true
         },
-        "acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
-        },
-        "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+        "acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "acorn": "^8.11.0"
             }
         },
         "amdefine": {
@@ -3952,10 +2967,10 @@
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
         "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "devOptional": true
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "dev": true
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -3970,36 +2985,10 @@
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
         },
-        "anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-            "dev": true,
-            "requires": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-            }
-        },
         "app-root-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
             "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw=="
-        },
-        "aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-            "devOptional": true
-        },
-        "are-we-there-yet": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-            "devOptional": true,
-            "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-            }
         },
         "arg": {
             "version": "4.1.3",
@@ -4038,12 +3027,6 @@
                 }
             }
         },
-        "array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true
-        },
         "atomic-sleep": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -4060,26 +3043,18 @@
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "better-sqlite3": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.5.0.tgz",
-            "integrity": "sha512-6FdG9DoytYGDhLW7VWW1vxjEz7xHkqK6LnaUQYA8d6GHNgZhu9PFX2xwKEEnSBRoT1J4PjTUPeg217ShxNmuPg==",
-            "devOptional": true,
+            "version": "11.8.1",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.8.1.tgz",
+            "integrity": "sha512-9BxNaBkblMjhJW8sMRZxnxVTRgbRmssZW0Oxc1MPBTfiR+WW21e2Mk4qu8CzrcZb1LwPCnFsfDEzq+SNcBU8eg==",
             "requires": {
                 "bindings": "^1.5.0",
-                "prebuild-install": "^7.0.0"
+                "prebuild-install": "^7.1.1"
             }
-        },
-        "binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "dev": true
         },
         "bindings": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "devOptional": true,
             "requires": {
                 "file-uri-to-path": "1.0.0"
             }
@@ -4088,7 +3063,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "devOptional": true,
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -4096,10 +3070,9 @@
             },
             "dependencies": {
                 "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "devOptional": true,
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -4117,36 +3090,14 @@
                 "concat-map": "0.0.1"
             }
         },
-        "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
-            "requires": {
-                "fill-range": "^7.0.1"
-            }
-        },
         "buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "devOptional": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
             }
-        },
-        "buffer-from": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
-        },
-        "callsites": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true
         },
         "camelcase": {
             "version": "5.0.0",
@@ -4198,27 +3149,10 @@
                 }
             }
         },
-        "chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "dev": true,
-            "requires": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "fsevents": "~2.3.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
-            }
-        },
         "chownr": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "devOptional": true
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "cli-highlight": {
             "version": "2.1.11",
@@ -4237,11 +3171,6 @@
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
                     "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
                 },
                 "string-width": {
                     "version": "4.2.3",
@@ -4297,11 +3226,6 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
                     "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
                 },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-                },
                 "string-width": {
                     "version": "4.2.3",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4321,12 +3245,6 @@
                     }
                 }
             }
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "devOptional": true
         },
         "color-convert": {
             "version": "1.9.3",
@@ -4363,12 +3281,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
-        "console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-            "devOptional": true
-        },
         "copyfiles": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
@@ -4388,12 +3300,6 @@
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
                     "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                     "dev": true
                 },
                 "string-width": {
@@ -4443,7 +3349,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "devOptional": true
+            "dev": true
         },
         "create-require": {
             "version": "1.1.1",
@@ -4479,7 +3385,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
             "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "devOptional": true,
             "requires": {
                 "mimic-response": "^3.1.0"
             }
@@ -4487,20 +3392,12 @@
         "deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "devOptional": true
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
-        "deep-is": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true
-        },
-        "delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-            "devOptional": true
+        "detect-libc": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
         },
         "diff": {
             "version": "4.0.2",
@@ -4508,37 +3405,16 @@
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
         },
-        "dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "requires": {
-                "path-type": "^4.0.0"
-            }
-        },
-        "doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "requires": {
-                "esutils": "^2.0.2"
-            }
-        },
         "dotenv": {
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
             "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
         },
-        "dynamic-dedupe": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
-            "integrity": "sha1-BuRMIj9eTpTXjvnbI6ZRXOL5YqE=",
-            "dev": true,
-            "requires": {
-                "xtend": "^4.0.0"
-            }
+        "eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -4563,243 +3439,15 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
-        "eslint": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
-            "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
-            "dev": true,
-            "requires": {
-                "@eslint/eslintrc": "^1.2.1",
-                "@humanwhocodes/config-array": "^0.9.2",
-                "ajv": "^6.10.0",
-                "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
-                "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.1",
-                "esquery": "^1.4.0",
-                "esutils": "^2.0.2",
-                "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^6.0.1",
-                "globals": "^13.6.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "js-yaml": "^4.1.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.0.4",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
-                "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-                    "dev": true
-                },
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
-                },
-                "escape-string-regexp": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-                    "dev": true
-                },
-                "eslint-scope": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-                    "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.3.0",
-                        "estraverse": "^5.2.0"
-                    }
-                },
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true
-                },
-                "glob-parent": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.3"
-                    }
-                },
-                "js-yaml": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^2.0.1"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1"
-                    }
-                }
-            }
-        },
-        "eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "requires": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            }
-        },
-        "eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "requires": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-                    "dev": true
-                }
-            }
-        },
-        "eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-            "dev": true
-        },
-        "espree": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-            "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
-            "dev": true,
-            "requires": {
-                "acorn": "^8.7.0",
-                "acorn-jsx": "^5.3.1",
-                "eslint-visitor-keys": "^3.3.0"
-            }
-        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
-        "esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^5.1.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true
-                }
-            }
-        },
-        "esrecurse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^5.2.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true
-                }
-            }
-        },
-        "estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true
-        },
-        "esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true
-        },
         "expand-template": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "devOptional": true
-        },
-        "fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            }
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
-        },
-        "fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
         },
         "fast-redact": {
             "version": "3.1.1",
@@ -4811,105 +3459,35 @@
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         },
-        "fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-            "dev": true,
-            "requires": {
-                "reusify": "^1.0.4"
-            }
-        },
-        "file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "dev": true,
-            "requires": {
-                "flat-cache": "^3.0.4"
-            }
-        },
         "file-uri-to-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "devOptional": true
-        },
-        "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
-            "requires": {
-                "to-regex-range": "^5.0.1"
-            }
-        },
-        "flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-            "dev": true,
-            "requires": {
-                "flatted": "^3.1.0",
-                "rimraf": "^3.0.2"
-            }
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
         "flatstr": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
             "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
         },
-        "flatted": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-            "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
-            "dev": true
+        "foreground-child": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+            "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            }
         },
         "fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "devOptional": true
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "optional": true
-        },
-        "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
-        },
-        "functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true
-        },
-        "gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "devOptional": true,
-            "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -4919,8 +3497,7 @@
         "github-from-package": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-            "devOptional": true
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
         },
         "glob": {
             "version": "7.1.6",
@@ -4935,67 +3512,15 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "requires": {
-                "is-glob": "^4.0.1"
-            }
-        },
-        "globals": {
-            "version": "13.12.1",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-            "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^0.20.2"
-            }
-        },
-        "globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "requires": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            }
-        },
-        "graceful-fs": {
-            "version": "4.2.9",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-            "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
-        },
         "graceful-readlink": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
         },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1"
-            }
-        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-            "devOptional": true
         },
         "highlight.js": {
             "version": "10.7.3",
@@ -5006,28 +3531,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-        },
-        "ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-            "dev": true
-        },
-        "import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-            "dev": true,
-            "requires": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            }
-        },
-        "imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true
         },
         "inflight": {
             "version": "1.0.6",
@@ -5046,68 +3549,33 @@
         "ini": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "devOptional": true
-        },
-        "is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
-            "requires": {
-                "binary-extensions": "^2.0.0"
-            }
-        },
-        "is-core-module": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-            "dev": true,
-            "requires": {
-                "has": "^1.0.3"
-            }
-        },
-        "is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "devOptional": true,
-            "requires": {
-                "number-is-nan": "^1.0.0"
-            }
-        },
-        "is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "requires": {
-                "is-extglob": "^2.1.1"
-            }
-        },
-        "is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "devOptional": true
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
+        },
+        "jackspeak": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
+            "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+            "dev": true,
+            "requires": {
+                "@isaacs/cliui": "^8.0.2"
+            }
         },
         "jmespath": {
             "version": "0.15.0",
@@ -5128,52 +3596,20 @@
                 "esprima": "^4.0.0"
             }
         },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
-        },
-        "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-            "dev": true
-        },
         "json5": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-            "requires": {
-                "minimist": "^1.2.5"
-            }
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
         },
         "leven": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
             "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
         },
-        "levn": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "^1.2.1",
-                "type-check": "~0.4.0"
-            }
-        },
-        "lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
         "lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "devOptional": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -5184,27 +3620,10 @@
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
         },
-        "merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true
-        },
-        "micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-            "dev": true,
-            "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
-            }
-        },
         "mimic-response": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "devOptional": true
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
         },
         "minimatch": {
             "version": "3.0.4",
@@ -5219,6 +3638,12 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
             "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
+        "minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true
+        },
         "mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -5227,8 +3652,7 @@
         "mkdirp-classic": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "devOptional": true
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "mri": {
             "version": "1.1.4",
@@ -5251,22 +3675,14 @@
             }
         },
         "napi-build-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "devOptional": true
-        },
-        "natural-compare": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
         },
         "node-abi": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.8.0.tgz",
-            "integrity": "sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==",
-            "devOptional": true,
+            "version": "3.73.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.73.0.tgz",
+            "integrity": "sha512-z8iYzQGBu35ZkTQ9mtR8RqugJZ9RCLn8fv3d7LsgDBzOijGQP3RdKTX4LA7LXw03ZhU5z0l4xfhIMgSES31+cg==",
             "requires": {
                 "semver": "^7.3.5"
             }
@@ -5307,30 +3723,6 @@
                 }
             }
         },
-        "normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
-        },
-        "npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "devOptional": true,
-            "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "devOptional": true
-        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5344,28 +3736,11 @@
                 "wrappy": "1"
             }
         },
-        "optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-            "dev": true,
-            "requires": {
-                "deep-is": "^0.1.3",
-                "fast-levenshtein": "^2.0.6",
-                "levn": "^0.4.1",
-                "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
-            }
-        },
-        "parent-module": {
+        "package-json-from-dist": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "requires": {
-                "callsites": "^3.0.0"
-            }
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true
         },
         "parse5": {
             "version": "5.1.1",
@@ -5398,23 +3773,23 @@
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true
         },
-        "path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
-        },
-        "path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true
-        },
-        "picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true
+        "path-scurry": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "11.0.2",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+                    "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+                    "dev": true
+                }
+            }
         },
         "pino": {
             "version": "6.14.0",
@@ -5478,45 +3853,29 @@
             "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
         },
         "prebuild-install": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
-            "integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
-            "devOptional": true,
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
             "requires": {
                 "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
                 "github-from-package": "0.0.0",
                 "minimist": "^1.2.3",
                 "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^1.0.1",
+                "napi-build-utils": "^2.0.0",
                 "node-abi": "^3.3.0",
-                "npmlog": "^4.0.1",
                 "pump": "^3.0.0",
                 "rc": "^1.2.7",
                 "simple-get": "^4.0.0",
                 "tar-fs": "^2.0.0",
                 "tunnel-agent": "^0.6.0"
-            },
-            "dependencies": {
-                "detect-libc": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-                    "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
-                    "devOptional": true
-                }
             }
-        },
-        "prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true
         },
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "devOptional": true
+            "dev": true
         },
         "process-warning": {
             "version": "1.0.0",
@@ -5532,18 +3891,6 @@
                 "once": "^1.3.1"
             }
         },
-        "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
-        },
-        "queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true
-        },
         "quick-format-unescaped": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -5553,7 +3900,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "devOptional": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -5564,8 +3910,7 @@
                 "strip-json-comments": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "devOptional": true
+                    "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
                 }
             }
         },
@@ -5573,7 +3918,7 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -5584,53 +3929,15 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
-            "requires": {
-                "picomatch": "^2.2.1"
-            }
-        },
         "reflect-metadata": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
             "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
         },
-        "regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true
-        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-        },
-        "resolve": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-            "dev": true,
-            "requires": {
-                "is-core-module": "^2.8.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            }
-        },
-        "resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true
-        },
-        "reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true
         },
         "rfdc": {
             "version": "1.3.0",
@@ -5638,21 +3945,47 @@
             "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
         },
         "rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+            "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.3"
-            }
-        },
-        "run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "requires": {
-                "queue-microtask": "^1.2.2"
+                "glob": "^11.0.0",
+                "package-json-from-dist": "^1.0.0"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "11.0.1",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+                    "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+                    "dev": true,
+                    "requires": {
+                        "foreground-child": "^3.1.0",
+                        "jackspeak": "^4.0.1",
+                        "minimatch": "^10.0.0",
+                        "minipass": "^7.1.2",
+                        "package-json-from-dist": "^1.0.0",
+                        "path-scurry": "^2.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "10.0.1",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+                    "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
             }
         },
         "safe-buffer": {
@@ -5669,16 +4002,9 @@
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
             "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "devOptional": true,
             "requires": {
                 "lru-cache": "^6.0.0"
             }
-        },
-        "set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-            "devOptional": true
         },
         "sha.js": {
             "version": "2.4.11",
@@ -5705,33 +4031,25 @@
             "dev": true
         },
         "signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-            "devOptional": true
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true
         },
         "simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "devOptional": true
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
         },
         "simple-get": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
             "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "devOptional": true,
             "requires": {
                 "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
             }
-        },
-        "slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true
         },
         "sonic-boom": {
             "version": "2.6.0",
@@ -5739,22 +4057,6 @@
             "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
             "requires": {
                 "atomic-sleep": "^1.0.0"
-            }
-        },
-        "source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
-        },
-        "source-map-support": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
             }
         },
         "split2": {
@@ -5782,11 +4084,6 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
-        "sqlite": {
-            "version": "4.0.25",
-            "resolved": "https://registry.npmjs.org/sqlite/-/sqlite-4.0.25.tgz",
-            "integrity": "sha512-gqCEcLF8FOTeW/na3SRYWLQkw2jZXgVj1DdgRJbm0jvrhnUgBIuNDUUm649AnBNDNHhI5XskwT8dvc8vearRLQ=="
-        },
         "string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -5796,30 +4093,77 @@
             }
         },
         "string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "devOptional": true,
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
             "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "dependencies": {
+                "emoji-regex": {
+                    "version": "9.2.2",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+                    "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+                    "dev": true
+                }
+            }
+        },
+        "string-width-cjs": {
+            "version": "npm:string-width@4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.1"
+                    }
+                }
             }
         },
         "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "devOptional": true,
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "^6.0.1"
             }
         },
-        "strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-            "dev": true
+        "strip-ansi-cjs": {
+            "version": "npm:strip-ansi@6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^5.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                    "dev": true
+                }
+            }
         },
         "strip-json-comments": {
             "version": "3.1.1",
@@ -5834,17 +4178,10 @@
                 "has-flag": "^3.0.0"
             }
         },
-        "supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "dev": true
-        },
         "tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "devOptional": true,
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+            "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
             "requires": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -5856,7 +4193,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "devOptional": true,
             "requires": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -5866,10 +4202,9 @@
             },
             "dependencies": {
                 "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "devOptional": true,
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -5877,12 +4212,6 @@
                     }
                 }
             }
-        },
-        "text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
         },
         "thenify": {
             "version": "3.3.1",
@@ -5910,134 +4239,44 @@
                 "xtend": "~4.0.1"
             }
         },
-        "to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+        "ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "requires": {
-                "is-number": "^7.0.0"
-            }
-        },
-        "tree-kill": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-            "dev": true
-        },
-        "ts-node-dev": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-            "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
-            "dev": true,
-            "requires": {
-                "chokidar": "^3.5.1",
-                "dynamic-dedupe": "^0.3.0",
-                "minimist": "^1.2.5",
-                "mkdirp": "^1.0.4",
-                "resolve": "^1.0.0",
-                "rimraf": "^2.6.1",
-                "source-map-support": "^0.5.12",
-                "tree-kill": "^1.2.2",
-                "ts-node": "^9.0.0",
-                "tsconfig": "^7.0.0"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "ts-node": {
-                    "version": "9.1.1",
-                    "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-                    "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-                    "dev": true,
-                    "requires": {
-                        "arg": "^4.1.0",
-                        "create-require": "^1.1.0",
-                        "diff": "^4.0.1",
-                        "make-error": "^1.1.1",
-                        "source-map-support": "^0.5.17",
-                        "yn": "3.1.1"
-                    }
-                }
-            }
-        },
-        "tsconfig": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-            "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-            "dev": true,
-            "requires": {
-                "@types/strip-bom": "^3.0.0",
-                "@types/strip-json-comments": "0.0.30",
-                "strip-bom": "^3.0.0",
-                "strip-json-comments": "^2.0.0"
-            },
-            "dependencies": {
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "dev": true
-                }
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
             }
         },
         "tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
-                }
-            }
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "devOptional": true,
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
         },
-        "type-check": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "^1.2.1"
-            }
-        },
-        "type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true
-        },
         "typeorm": {
-            "version": "0.2.44",
-            "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.44.tgz",
-            "integrity": "sha512-yFyb9Ts73vGaS/O06TvLpzvT5U/ngO31GeciNc0eoH7P1QcG8kVZdOy9FHJqkTeDmIljMRgWjbYUoMw53ZY7Xw==",
+            "version": "0.2.45",
+            "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
+            "integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
             "requires": {
                 "@sqltools/formatter": "^1.2.2",
                 "app-root-path": "^3.0.0",
@@ -6083,24 +4322,22 @@
             }
         },
         "typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "dev": true
+        },
+        "undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "dev": true
         },
         "untildify": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
             "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
             "dev": true
-        },
-        "uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "requires": {
-                "punycode": "^2.1.0"
-            }
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -6112,10 +4349,10 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
-        "v8-compile-cache": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+        "v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true
         },
         "which": {
@@ -6126,21 +4363,6 @@
             "requires": {
                 "isexe": "^2.0.0"
             }
-        },
-        "wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "devOptional": true,
-            "requires": {
-                "string-width": "^1.0.2 || 2"
-            }
-        },
-        "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true
         },
         "wrap-ansi": {
             "version": "7.0.0",
@@ -6178,11 +4400,6 @@
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
                 },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-                },
                 "string-width": {
                     "version": "4.2.3",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6197,6 +4414,69 @@
                     "version": "6.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
                     "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "requires": {
+                        "ansi-regex": "^5.0.1"
+                    }
+                }
+            }
+        },
+        "wrap-ansi-cjs": {
+            "version": "npm:wrap-ansi@7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.1"
                     }
@@ -6236,21 +4516,20 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "devOptional": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yargs": {
-            "version": "17.3.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-            "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "requires": {
-                "cliui": "^7.0.2",
+                "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
                 "string-width": "^4.2.3",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^21.0.0"
+                "yargs-parser": "^21.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -6258,10 +4537,15 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
                     "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
                 },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+                "cliui": {
+                    "version": "8.0.1",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+                    "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.1",
+                        "wrap-ansi": "^7.0.0"
+                    }
                 },
                 "string-width": {
                     "version": "4.2.3",
@@ -6284,9 +4568,9 @@
             }
         },
         "yargs-parser": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-            "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         },
         "yn": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@runejs/store",
-    "version": "1.0.0-beta.1",
+    "version": "1.0.0-beta.2",
     "description": "Tools for managing and indexing the asset file store used with RuneJS.",
     "main": "./index.js",
     "types": "./index.d.ts",
@@ -15,12 +15,16 @@
     },
     "scripts": {
         "build": "tsc",
-        "start": "ts-node-dev src/dev.ts",
-        "lint": "eslint --ext .ts src",
-        "lint:fix": "eslint --ext .ts src --fix",
-        "unpack": "ts-node-dev --max-old-space-size=2048 src/scripts/unpacker.ts",
+        "clean": "rimraf indexes && rimraf lib && rimraf logs && rimraf unpacked",
+        "lint": "biome lint",
+        "lint:fix": "biome lint --write",
+        "format": "biome format",
+        "format:fix": "biome format --write",
+        "fin": "npm run lint:fix && npm run format:fix",
+        "start": "ts-node src/dev.ts",
+        "unpack": "ts-node src/scripts/unpacker.ts",
         "unpacker": "npm run unpack",
-        "index": "ts-node-dev --max-old-space-size=2048 src/scripts/indexer.ts",
+        "index": "ts-node src/scripts/indexer.ts",
         "indexer": "npm run index",
         "copy-documents": "copyfiles package.json README.md .npmignore LICENSE lib",
         "package": "rimraf lib && npm i && npm run build && npm run copy-documents && cd lib && npm publish --dry-run",
@@ -48,42 +52,25 @@
     },
     "homepage": "https://github.com/runejs/store#readme",
     "peerDependencies": {
-        "@runejs/common": "2.0.2-beta.2",
-        "graceful-fs": ">=4.2.0",
-        "tslib": ">=2.3.0",
-        "typescript": ">=4.5.0"
+        "@runejs/common": "2.0.2-beta.3",
+        "tslib": ">=2.8.1",
+        "typescript": "^5.7.3"
     },
     "dependencies": {
-        "@runejs/common": "2.0.2-beta.2",
-        "graceful-fs": "^4.2.0",
-        "json5": "^2.2.0",
-        "reflect-metadata": "^0.1.13",
-        "sqlite": "^4.0.25",
-        "tslib": "^2.3.1",
-        "typeorm": "^0.2.44",
-        "yargs": "^17.3.1"
+        "@runejs/common": "2.0.2-beta.3",
+        "better-sqlite3": "^11.8.1",
+        "json5": "^2.2.3",
+        "tslib": ">=2.8.1",
+        "typeorm": "^0.2.45",
+        "yargs": "^17.7.2"
     },
     "devDependencies": {
-        "@runejs/eslint-config": "^1.1.0",
-        "@types/graceful-fs": "^4.1.5",
-        "@types/node": "^16.11.26",
-        "@types/yargs": "^17.0.9",
-        "@typescript-eslint/eslint-plugin": "^5.14.0",
-        "@typescript-eslint/parser": "^5.14.0",
-        "better-sqlite3": "^7.5.0",
+        "@biomejs/biome": "1.9.4",
+        "@types/node": "^22.10.7",
+        "@types/yargs": "^17.0.33",
         "copyfiles": "^2.4.1",
-        "eslint": "^8.11.0",
-        "rimraf": "^3.0.2",
-        "source-map-support": "^0.5.21",
-        "ts-node-dev": "^1.1.8",
-        "typescript": "^4.5.5"
-    },
-    "eslintConfig": {
-        "extends": [
-            "@runejs/eslint-config"
-        ],
-        "parserOptions": {
-            "project": "./tsconfig.json"
-        }
+        "rimraf": "6.0.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.7.3"
     }
 }

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -8,15 +8,17 @@ import { type FileBreadcrumb, IndexedFile } from './indexed-file';
 import type { ArchiveConfig } from './config';
 import { archiveFlags } from './config/archive-flags';
 
-
 export class Archive extends IndexedFile<ArchiveIndexEntity> {
-
     public readonly config: ArchiveConfig;
     public readonly groups: Map<string, Group>;
 
     private _missingEncryptionKeys: number;
 
-    public constructor(index: ArchiveIndexEntity, config: ArchiveConfig, breadcrumb?: Partial<FileBreadcrumb>) {
+    public constructor(
+        index: ArchiveIndexEntity,
+        config: ArchiveConfig,
+        breadcrumb?: Partial<FileBreadcrumb>,
+    ) {
         super(index, breadcrumb);
 
         this.groups = new Map<string, Group>();
@@ -38,74 +40,87 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
 
         logger.info(`Archive ${this.name} checksum: ${this.crc32}`);
 
-        if(this.numericKey === 255) {
+        if (this.numericKey === 255) {
             return this.data;
         }
 
         this.decompress();
 
-        if(!this._data?.length) {
+        if (!this._data?.length) {
             logger.error('Error decompressing file data.');
             return null;
         }
 
         const archiveData = this._data;
         // biome-ignore lint/suspicious/noAssignInExpressions: Legacy
-        const format = this.index.format = archiveData.get('byte', 'unsigned');
-        const mainDataType = format >= ArchiveFormat.smart ? 'smart_int' : 'short';
-        this.index.version = format >= ArchiveFormat.versioned ? archiveData.get('int') : 0;
+        const format = (this.index.format = archiveData.get(
+            'byte',
+            'unsigned',
+        ));
+        const mainDataType =
+            format >= ArchiveFormat.smart ? 'smart_int' : 'short';
+        this.index.version =
+            format >= ArchiveFormat.versioned ? archiveData.get('int') : 0;
         const flags = archiveFlags(archiveData.get('byte', 'unsigned'));
         const groupCount = archiveData.get(mainDataType, 'unsigned');
 
-        logger.info(`${groupCount} groups were found within the ${this.name} archive.`);
+        logger.info(
+            `${groupCount} groups were found within the ${this.name} archive.`,
+        );
 
         const groupKeys: number[] = new Array(groupCount);
         const groupChildCounts: Map<number, number> = new Map<number, number>();
         let accumulator = 0;
 
         // Group index keys
-        for(let i = 0; i < groupCount; i++) {
+        for (let i = 0; i < groupCount; i++) {
             const delta = archiveData.get(mainDataType, 'unsigned');
             groupKeys[i] = accumulator += delta;
-            const group = new Group(this.indexService.validateGroup({
-                numericKey: groupKeys[i],
-                name: String(groupKeys[i]),
-                archive: this
-            }), {
-                store: this.store,
-                archive: this
-            });
+            const group = new Group(
+                this.indexService.validateGroup({
+                    numericKey: groupKeys[i],
+                    name: String(groupKeys[i]),
+                    archive: this,
+                }),
+                {
+                    store: this.store,
+                    archive: this,
+                },
+            );
 
             group.setState(FileState.encoded);
             this.set(groupKeys[i], group);
         }
 
         // Group names
-        if(flags.groupNames) {
-            for(const groupIndex of groupKeys) {
+        if (flags.groupNames) {
+            for (const groupIndex of groupKeys) {
                 const group = this.get(groupIndex);
                 group.nameHash = group.index.nameHash = archiveData.get('int');
-                group.name = group.index.name = this.store.findFileName(group.nameHash, String(group.nameHash));
+                group.name = group.index.name = this.store.findFileName(
+                    group.nameHash,
+                    String(group.nameHash),
+                );
             }
         }
 
         // Compressed file data CRC32 checksums
-        for(const key of groupKeys) {
+        for (const key of groupKeys) {
             const group = this.get(key);
             group.crc32 = archiveData.get('int');
         }
 
         // Decompressed file data CRC32 checksums
-        if(flags.decompressedCrcs) {
-            for(const key of groupKeys) {
+        if (flags.decompressedCrcs) {
+            for (const key of groupKeys) {
                 const decompressedCrc32 = archiveData.get('int');
                 // @TODO assign to group (requires changing existing 'crc32' to 'compressedCrc`)
             }
         }
 
         // File data whirlpool digests
-        if(flags.whirlpoolDigests) {
-            for(const key of groupKeys) {
+        if (flags.whirlpoolDigests) {
+            for (const key of groupKeys) {
                 const whirlpoolDigest = new ByteBuffer(512);
                 archiveData.getBytes(whirlpoolDigest, 512);
                 // @TODO assign to group
@@ -113,8 +128,8 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
         }
 
         // Group file sizes
-        if(flags.groupSizes) {
-            for(const key of groupKeys) {
+        if (flags.groupSizes) {
+            for (const key of groupKeys) {
                 const compressedSize = archiveData.get('int');
                 const decompressedSize = archiveData.get('int');
                 // @TODO assign to group (requires changing existing 'size' to 'compressedSize')
@@ -122,65 +137,76 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
         }
 
         // Group version numbers
-        for(const key of groupKeys) {
+        for (const key of groupKeys) {
             const group = this.get(key);
             group.version = archiveData.get('int');
         }
 
         // Group file counts
-        for(const key of groupKeys) {
+        for (const key of groupKeys) {
             groupChildCounts.set(key, archiveData.get('short', 'unsigned'));
         }
 
         // Grouped file index keys
-        for(const key of groupKeys) {
+        for (const key of groupKeys) {
             const group = this.get(key) as Group;
             const fileCount = groupChildCounts.get(key);
 
             accumulator = 0;
-            for(let i = 0; i < fileCount; i++) {
+            for (let i = 0; i < fileCount; i++) {
                 const delta = archiveData.get(mainDataType, 'unsigned');
                 // biome-ignore lint/suspicious/noAssignInExpressions: Lecacy
-                const childFileIndex = accumulator += delta;
-                group.set(childFileIndex, new FlatFile(this.indexService.validateFile({
-                    numericKey: childFileIndex,
-                    name: String(childFileIndex),
-                    group, archive: this
-                }), {
-                    store: this.store,
-                    archive: this,
-                    group: group
-                }));
+                const childFileIndex = (accumulator += delta);
+                group.set(
+                    childFileIndex,
+                    new FlatFile(
+                        this.indexService.validateFile({
+                            numericKey: childFileIndex,
+                            name: String(childFileIndex),
+                            group,
+                            archive: this,
+                        }),
+                        {
+                            store: this.store,
+                            archive: this,
+                            group: group,
+                        },
+                    ),
+                );
             }
         }
 
         // Grouped file names
-        if(flags.groupNames) {
-            for(const key of groupKeys) {
+        if (flags.groupNames) {
+            for (const key of groupKeys) {
                 const fileGroup = this.get(key) as Group;
 
-                for(const [ , file ] of fileGroup.files) {
+                for (const [, file] of fileGroup.files) {
                     const nameHash = archiveData.get('int');
-                    if(file) {
+                    if (file) {
                         file.nameHash = file.index.nameHash = nameHash;
-                        file.name = file.index.name =
-                            this.store.findFileName(file.nameHash, String(file.nameHash));
+                        file.name = file.index.name = this.store.findFileName(
+                            file.nameHash,
+                            String(file.nameHash),
+                        );
                     }
                 }
             }
         }
 
-        if(decodeGroups) {
-            for(const [ , group ] of this.groups) {
+        if (decodeGroups) {
+            for (const [, group] of this.groups) {
                 try {
                     group.decode();
-                } catch(error) {
+                } catch (error) {
                     logger.error(error);
                 }
             }
 
-            if(this.missingEncryptionKeys) {
-                logger.error(`Missing ${this.missingEncryptionKeys} XTEA decryption key(s).`);
+            if (this.missingEncryptionKeys) {
+                logger.error(
+                    `Missing ${this.missingEncryptionKeys} XTEA decryption key(s).`,
+                );
             }
         } else {
             logger.info(`${groupCount} groups(s) were found.`);
@@ -191,7 +217,7 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
     }
 
     public override encode(encodeGroups = true): ByteBuffer | null {
-        if(this.numericKey === 255) {
+        if (this.numericKey === 255) {
             return this.store.encode();
         }
 
@@ -208,40 +234,40 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
 
         // Write file indexes
         let writtenFileIndex = 0;
-        for(const [ , group ] of groups) {
+        for (const [, group] of groups) {
             const val = group.numericKey;
             buffer.put(val - writtenFileIndex, 'short');
             writtenFileIndex = val;
         }
 
         // Write name hashes (if applicable)
-        if(this.config.filesNamed) {
-            for(const [ , file ] of groups) {
+        if (this.config.filesNamed) {
+            for (const [, file] of groups) {
                 buffer.put(file.nameHash ?? -1, 'int');
             }
         }
 
         // Write file crc values
-        for(const [ , file ] of groups) {
+        for (const [, file] of groups) {
             buffer.put(file.crc32 ?? -1, 'int');
         }
 
         // Write file version numbers
-        for(const [ , ] of groups) {
+        for (const [,] of groups) {
             buffer.put(0, 'int');
         }
 
         // Write file group child counts
-        for(const [ , group ] of groups) {
+        for (const [, group] of groups) {
             buffer.put(group.files.size ?? 1, 'short');
         }
 
         // Write group file indices
-        for(const [ , group ] of groups) {
-            if(group.files.size > 1) {
+        for (const [, group] of groups) {
+            if (group.files.size > 1) {
                 writtenFileIndex = 0;
 
-                for(const [ , file ] of group.files) {
+                for (const [, file] of group.files) {
                     const i = file.numericKey;
                     buffer.put(i - writtenFileIndex, 'short');
                     writtenFileIndex = i;
@@ -252,10 +278,10 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
         }
 
         // Write group file name hashes (if applicable)
-        if(this.config.filesNamed) {
-            for(const [ , group ] of groups) {
-                if(group.files.size > 1) {
-                    for(const [ , file ] of group.files) {
+        if (this.config.filesNamed) {
+            for (const [, group] of groups) {
+                if (group.files.size > 1) {
+                    for (const [, file] of group.files) {
                         buffer.put(file.nameHash ?? -1, 'int');
                     }
                 } else {
@@ -266,60 +292,67 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
 
         const indexData = buffer?.flipWriter();
 
-        if(indexData?.length) {
+        if (indexData?.length) {
             this.setData(indexData, FileState.encoded);
             this.sha256 = this.index.sha256 = this.generateSha256();
         }
 
-        if(encodeGroups) {
-            this.groups.forEach(group => group.encode());
+        if (encodeGroups) {
+            this.groups.forEach((group) => group.encode());
         }
 
         return this.data ?? null;
     }
 
     public override compress(compressGroups = true): ByteBuffer | null {
-        if(compressGroups) {
-            this.groups.forEach(group => group.compress());
+        if (compressGroups) {
+            this.groups.forEach((group) => group.compress());
         }
         return super.compress();
     }
 
-    public override async read(compress = false, readDiskFiles = true): Promise<ByteBuffer> {
+    public override async read(
+        compress = false,
+        readDiskFiles = true,
+    ): Promise<ByteBuffer> {
         logger.info(`Reading archive ${this.name}...`);
 
         // Read in all groups within the archive
         const groupIndexes = await this.index.groups;
-        for(const groupIndex of groupIndexes) {
+        for (const groupIndex of groupIndexes) {
             const group = new Group(groupIndex, {
                 store: this.store,
-                archive: this
+                archive: this,
             });
 
             this.groups.set(group.key, group);
             await group.read(false, readDiskFiles);
         }
 
-        if(compress) {
+        if (compress) {
             // Then compress them, if needed
-            for(const [ , group ] of this.groups) {
+            for (const [, group] of this.groups) {
                 group.compress();
             }
         }
 
-        logger.info(`${this.groups.size} groups(s) were loaded from the ${this.name} archive.`);
+        logger.info(
+            `${this.groups.size} groups(s) were loaded from the ${this.name} archive.`,
+        );
 
         this.encode();
 
-        if(compress) {
+        if (compress) {
             return this.compress();
         }
-            return this._data;
+        return this._data;
     }
 
     public override write(): void {
-        if(!this.groups.size) {
-            logger.error(`Error writing archive ${this.name || this.key}: Archive is empty.`);
+        if (!this.groups.size) {
+            logger.error(
+                `Error writing archive ${this.name || this.key}: Archive is empty.`,
+            );
             return;
         }
 
@@ -328,20 +361,25 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
 
         const archivePath = this.outputPath;
 
-        if(existsSync(archivePath)) {
+        if (existsSync(archivePath)) {
             rmSync(archivePath, { recursive: true, force: true });
         }
 
         mkdirSync(archivePath, { recursive: true });
 
-        Array.from(this.groups.values()).forEach(group => group.write());
+        Array.from(this.groups.values()).forEach((group) => group.write());
 
         const end = Date.now();
-        logger.info(`Archive ${this.name || this.key} written in ${(end - start) / 1000} seconds.`)
+        logger.info(
+            `Archive ${this.name || this.key} written in ${(end - start) / 1000} seconds.`,
+        );
     }
 
-    public async saveIndexData(saveGroups = true, saveFiles = true): Promise<void> {
-        if(!this.groups.size) {
+    public async saveIndexData(
+        saveGroups = true,
+        saveFiles = true,
+    ): Promise<void> {
+        if (!this.groups.size) {
             return;
         }
 
@@ -349,7 +387,7 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
 
         await this.indexService.saveArchiveIndex(this);
 
-        if(saveGroups) {
+        if (saveGroups) {
             await this.saveGroupIndexes(saveFiles);
         }
 
@@ -359,32 +397,34 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
     public async saveGroupIndexes(saveFlatFiles = true): Promise<void> {
         const groups = Array.from(this.groups.values());
 
-        if(groups?.length) {
-            logger.info(`Saving archive ${ this.name } group indexes...`);
+        if (groups?.length) {
+            logger.info(`Saving archive ${this.name} group indexes...`);
             await this.indexService.saveGroupIndexes(groups);
         }
 
-        if(saveFlatFiles) {
+        if (saveFlatFiles) {
             await this.saveFlatFileIndexes();
         }
     }
 
     public async saveFlatFileIndexes(): Promise<void> {
-        if(this.config.flatten) {
+        if (this.config.flatten) {
             return;
         }
 
         const groups = Array.from(this.groups.values());
-        const flatFiles = groups.filter(group => {
-            if(!group?.files?.size || group?.index?.flatFile) {
-                return false;
-            }
-            return group.files.size > 1;
-        }).map(group => Array.from(group.files.values()))
+        const flatFiles = groups
+            .filter((group) => {
+                if (!group?.files?.size || group?.index?.flatFile) {
+                    return false;
+                }
+                return group.files.size > 1;
+            })
+            .map((group) => Array.from(group.files.values()))
             .reduce((a, v) => a.concat(v), []);
 
-        if(flatFiles?.length) {
-            logger.info(`Saving archive ${ this.name } flat file indexes...`);
+        if (flatFiles?.length) {
+            logger.info(`Saving archive ${this.name} flat file indexes...`);
             await this.indexService.saveFileIndexes(flatFiles);
         }
     }
@@ -412,7 +452,7 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
 
     public find(groupName: string): Archive | Group | FlatFile | null {
         const children = Array.from(this.groups.values());
-        return children.find(child => child?.name === groupName) ?? null;
+        return children.find((child) => child?.name === groupName) ?? null;
     }
 
     public incrementMissingEncryptionKeys(): void {
@@ -424,22 +464,30 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
     }
 
     public override get path(): string {
-        if(!this.store?.path) {
-            throw new Error(`Error generating archive path; Store path not provided for archive ${this.key}.`);
+        if (!this.store?.path) {
+            throw new Error(
+                `Error generating archive path; Store path not provided for archive ${this.key}.`,
+            );
         }
-        if(!this.name) {
-            throw new Error(`Error generating archive path; Name not provided for archive ${this.key}.`);
+        if (!this.name) {
+            throw new Error(
+                `Error generating archive path; Name not provided for archive ${this.key}.`,
+            );
         }
 
         return join(this.store.path, 'unpacked', this.name);
     }
 
     public override get outputPath(): string {
-        if(!this.store?.outputPath) {
-            throw new Error(`Error generating archive output path; Store output path not provided for archive ${this.key}.`);
+        if (!this.store?.outputPath) {
+            throw new Error(
+                `Error generating archive output path; Store output path not provided for archive ${this.key}.`,
+            );
         }
-        if(!this.name) {
-            throw new Error(`Error generating archive output path; Name not provided for archive ${this.key}.`);
+        if (!this.name) {
+            throw new Error(
+                `Error generating archive output path; Name not provided for archive ${this.key}.`,
+            );
         }
 
         return join(this.store.outputPath, this.name);
@@ -448,5 +496,4 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
     public get versioned(): boolean {
         return this.config.versioned;
     }
-
 }

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,11 +1,11 @@
-import { join } from 'path';
-import { existsSync, mkdirSync, rmSync } from 'graceful-fs';
+import { join } from 'node:path';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { ByteBuffer, logger } from '@runejs/common';
 
 import { ArchiveFormat, FileState, FlatFile, Group } from './index';
-import { ArchiveIndexEntity } from './db';
-import { FileBreadcrumb, IndexedFile } from './indexed-file';
-import { ArchiveConfig } from './config';
+import type { ArchiveIndexEntity } from './db';
+import { type FileBreadcrumb, IndexedFile } from './indexed-file';
+import type { ArchiveConfig } from './config';
 import { archiveFlags } from './config/archive-flags';
 
 
@@ -29,7 +29,7 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
         this.compression = this.config.compression || 'none';
     }
 
-    public override decode(decodeGroups: boolean = true): ByteBuffer | null {
+    public override decode(decodeGroups = true): ByteBuffer | null {
         logger.info(`Decoding archive ${this.name}...`);
 
         this._missingEncryptionKeys = 0;
@@ -45,11 +45,12 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
         this.decompress();
 
         if(!this._data?.length) {
-            logger.error(`Error decompressing file data.`);
+            logger.error('Error decompressing file data.');
             return null;
         }
 
         const archiveData = this._data;
+        // biome-ignore lint/suspicious/noAssignInExpressions: Legacy
         const format = this.index.format = archiveData.get('byte', 'unsigned');
         const mainDataType = format >= ArchiveFormat.smart ? 'smart_int' : 'short';
         this.index.version = format >= ArchiveFormat.versioned ? archiveData.get('int') : 0;
@@ -139,6 +140,7 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
             accumulator = 0;
             for(let i = 0; i < fileCount; i++) {
                 const delta = archiveData.get(mainDataType, 'unsigned');
+                // biome-ignore lint/suspicious/noAssignInExpressions: Lecacy
                 const childFileIndex = accumulator += delta;
                 group.set(childFileIndex, new FlatFile(this.indexService.validateFile({
                     numericKey: childFileIndex,
@@ -188,7 +190,7 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
         return this._data ?? null;
     }
 
-    public override encode(encodeGroups: boolean = true): ByteBuffer | null {
+    public override encode(encodeGroups = true): ByteBuffer | null {
         if(this.numericKey === 255) {
             return this.store.encode();
         }
@@ -276,14 +278,14 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
         return this.data ?? null;
     }
 
-    public override compress(compressGroups: boolean = true): ByteBuffer | null {
+    public override compress(compressGroups = true): ByteBuffer | null {
         if(compressGroups) {
             this.groups.forEach(group => group.compress());
         }
         return super.compress();
     }
 
-    public override async read(compress: boolean = false, readDiskFiles: boolean = true): Promise<ByteBuffer> {
+    public override async read(compress = false, readDiskFiles = true): Promise<ByteBuffer> {
         logger.info(`Reading archive ${this.name}...`);
 
         // Read in all groups within the archive
@@ -311,9 +313,8 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
 
         if(compress) {
             return this.compress();
-        } else {
-            return this._data;
         }
+            return this._data;
     }
 
     public override write(): void {
@@ -339,7 +340,7 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
         logger.info(`Archive ${this.name || this.key} written in ${(end - start) / 1000} seconds.`)
     }
 
-    public async saveIndexData(saveGroups: boolean = true, saveFiles: boolean = true): Promise<void> {
+    public async saveIndexData(saveGroups = true, saveFiles = true): Promise<void> {
         if(!this.groups.size) {
             return;
         }
@@ -355,7 +356,7 @@ export class Archive extends IndexedFile<ArchiveIndexEntity> {
         logger.info(`Archive ${this.name} indexing complete.`);
     }
 
-    public async saveGroupIndexes(saveFlatFiles: boolean = true): Promise<void> {
+    public async saveGroupIndexes(saveFlatFiles = true): Promise<void> {
         const groups = Array.from(this.groups.values());
 
         if(groups?.length) {

--- a/src/config/archive-config.ts
+++ b/src/config/archive-config.ts
@@ -1,13 +1,12 @@
 import type { CompressionMethod } from '@runejs/common/compress';
 import type { EncryptionMethod } from '@runejs/common/encrypt';
 
-
 export interface ArchiveConfig {
     index: number;
     name: string;
     versioned?: boolean;
     compression?: CompressionMethod;
-    encryption?: EncryptionMethod | [ EncryptionMethod, string ];
+    encryption?: EncryptionMethod | [EncryptionMethod, string];
     contentType?: string;
     filesNamed?: boolean;
     flatten?: boolean;

--- a/src/config/archive-config.ts
+++ b/src/config/archive-config.ts
@@ -1,5 +1,5 @@
-import { CompressionMethod } from '@runejs/common/compress';
-import { EncryptionMethod } from '@runejs/common/encrypt';
+import type { CompressionMethod } from '@runejs/common/compress';
+import type { EncryptionMethod } from '@runejs/common/encrypt';
 
 
 export interface ArchiveConfig {

--- a/src/db/archive-index.entity.ts
+++ b/src/db/archive-index.entity.ts
@@ -3,7 +3,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne, OneToMany, PrimaryColumn 
 import { IndexEntity } from './index-entity';
 import { StoreIndexEntity } from './store-index.entity';
 import { GroupIndexEntity } from './group-index.entity';
-import { FileState } from '../file-state';
+import type { FileState } from '../file-state';
 import { ArchiveFormat } from '../config';
 
 
@@ -15,13 +15,13 @@ export class ArchiveIndexEntity extends IndexEntity {
     gameBuild: string;
 
     @Column('integer', { name: 'group_count', nullable: false, default: 0 })
-    groupCount: number = 0;
+    groupCount = 0;
 
     @Column('integer', { name: 'format', nullable: false, default: ArchiveFormat.original })
     format: number = ArchiveFormat.original;
 
     @Column('integer', { nullable: false, default: 0 })
-    version: number = 0;
+    version = 0;
 
     @Column('text', { name: 'data_state', nullable: false })
     state: FileState;

--- a/src/db/archive-index.entity.ts
+++ b/src/db/archive-index.entity.ts
@@ -1,4 +1,12 @@
-import { Column, Entity, Index, JoinColumn, ManyToOne, OneToMany, PrimaryColumn } from 'typeorm';
+import {
+    Column,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    OneToMany,
+    PrimaryColumn,
+} from 'typeorm';
 
 import { IndexEntity } from './index-entity';
 import { StoreIndexEntity } from './store-index.entity';
@@ -6,18 +14,24 @@ import { GroupIndexEntity } from './group-index.entity';
 import type { FileState } from '../file-state';
 import { ArchiveFormat } from '../config';
 
-
 @Entity('archive_index')
-@Index('archive_identifier', [ 'key', 'gameBuild' ], { unique: true })
+@Index('archive_identifier', ['key', 'gameBuild'], { unique: true })
 export class ArchiveIndexEntity extends IndexEntity {
-
-    @PrimaryColumn('text', { name: 'game_build', nullable: false, unique: false })
+    @PrimaryColumn('text', {
+        name: 'game_build',
+        nullable: false,
+        unique: false,
+    })
     gameBuild: string;
 
     @Column('integer', { name: 'group_count', nullable: false, default: 0 })
     groupCount = 0;
 
-    @Column('integer', { name: 'format', nullable: false, default: ArchiveFormat.original })
+    @Column('integer', {
+        name: 'format',
+        nullable: false,
+        default: ArchiveFormat.original,
+    })
     format: number = ArchiveFormat.original;
 
     @Column('integer', { nullable: false, default: 0 })
@@ -26,13 +40,18 @@ export class ArchiveIndexEntity extends IndexEntity {
     @Column('text', { name: 'data_state', nullable: false })
     state: FileState;
 
-    @ManyToOne(() => StoreIndexEntity, async store => store.archives,
-        { primary: true, onDelete: 'CASCADE' })
+    @ManyToOne(
+        () => StoreIndexEntity,
+        async (store) => store.archives,
+        { primary: true, onDelete: 'CASCADE' },
+    )
     @JoinColumn({ name: 'game_build', referencedColumnName: 'gameBuild' })
     store: StoreIndexEntity;
 
-    @OneToMany(() => GroupIndexEntity, group => group.archive,
-        { cascade: true, lazy: true })
+    @OneToMany(
+        () => GroupIndexEntity,
+        (group) => group.archive,
+        { cascade: true, lazy: true },
+    )
     groups: Promise<GroupIndexEntity[]> | GroupIndexEntity[];
-
 }

--- a/src/db/file-index.entity.ts
+++ b/src/db/file-index.entity.ts
@@ -20,13 +20,13 @@ export class FileIndexEntity extends IndexEntity {
     groupKey: number;
 
     @Column('integer', { name: 'name_hash', nullable: true, default: 0 })
-    nameHash: number = 0;
+    nameHash = 0;
 
     @Column('integer', { nullable: false, default: 0 })
-    version: number = 0;
+    version = 0;
 
     @Column('integer', { name: 'stripe_count', nullable: false, default: 1 })
-    stripeCount: number = 1;
+    stripeCount = 1;
 
     @Column('text', { nullable: true, default: null })
     stripes: string | null = null;

--- a/src/db/file-index.entity.ts
+++ b/src/db/file-index.entity.ts
@@ -1,22 +1,41 @@
-import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import {
+    Column,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryColumn,
+} from 'typeorm';
 
 import { IndexEntity } from './index-entity';
 import { StoreIndexEntity } from './store-index.entity';
 import { ArchiveIndexEntity } from './archive-index.entity';
 import { GroupIndexEntity } from './group-index.entity';
 
-
 @Entity('file_index')
-@Index('file_identifier', [ 'key', 'gameBuild', 'archiveKey', 'groupKey' ], { unique: true })
+@Index('file_identifier', ['key', 'gameBuild', 'archiveKey', 'groupKey'], {
+    unique: true,
+})
 export class FileIndexEntity extends IndexEntity {
-
-    @PrimaryColumn('text', { name: 'game_build', nullable: false, unique: false })
+    @PrimaryColumn('text', {
+        name: 'game_build',
+        nullable: false,
+        unique: false,
+    })
     gameBuild: string;
 
-    @PrimaryColumn('integer', { name: 'archive_key', unique: false, nullable: false })
+    @PrimaryColumn('integer', {
+        name: 'archive_key',
+        unique: false,
+        nullable: false,
+    })
     archiveKey: number;
 
-    @PrimaryColumn('integer', { name: 'group_key', unique: false, nullable: false })
+    @PrimaryColumn('integer', {
+        name: 'group_key',
+        unique: false,
+        nullable: false,
+    })
     groupKey: number;
 
     @Column('integer', { name: 'name_hash', nullable: true, default: 0 })
@@ -31,26 +50,34 @@ export class FileIndexEntity extends IndexEntity {
     @Column('text', { nullable: true, default: null })
     stripes: string | null = null;
 
-    @ManyToOne(() => StoreIndexEntity, async store => store.files,
-        { primary: true, onDelete: 'CASCADE' })
+    @ManyToOne(
+        () => StoreIndexEntity,
+        async (store) => store.files,
+        { primary: true, onDelete: 'CASCADE' },
+    )
     @JoinColumn({ name: 'game_build', referencedColumnName: 'gameBuild' })
     store: StoreIndexEntity;
 
-    @ManyToOne(() => ArchiveIndexEntity, async archive => archive.groups,
-        { primary: true, onDelete: 'CASCADE' })
+    @ManyToOne(
+        () => ArchiveIndexEntity,
+        async (archive) => archive.groups,
+        { primary: true, onDelete: 'CASCADE' },
+    )
     @JoinColumn([
         { name: 'archive_key', referencedColumnName: 'key' },
-        { name: 'game_build', referencedColumnName: 'gameBuild' }
+        { name: 'game_build', referencedColumnName: 'gameBuild' },
     ])
     archive: ArchiveIndexEntity;
 
-    @ManyToOne(() => GroupIndexEntity, async group => group.files,
-        { primary: true, onDelete: 'CASCADE' })
+    @ManyToOne(
+        () => GroupIndexEntity,
+        async (group) => group.files,
+        { primary: true, onDelete: 'CASCADE' },
+    )
     @JoinColumn([
         { name: 'archive_key', referencedColumnName: 'archiveKey' },
         { name: 'group_key', referencedColumnName: 'key' },
-        { name: 'game_build', referencedColumnName: 'gameBuild' }
+        { name: 'game_build', referencedColumnName: 'gameBuild' },
     ])
     group: GroupIndexEntity;
-
 }

--- a/src/db/group-index.entity.ts
+++ b/src/db/group-index.entity.ts
@@ -3,7 +3,7 @@ import { FileIndexEntity } from './file-index.entity';
 import { ArchiveIndexEntity } from './archive-index.entity';
 import { IndexEntity } from './index-entity';
 import { StoreIndexEntity } from './store-index.entity';
-import { FileState } from '../file-state';
+import type { FileState } from '../file-state';
 
 
 @Entity('group_index')
@@ -17,19 +17,19 @@ export class GroupIndexEntity extends IndexEntity {
     archiveKey: number;
 
     @Column('boolean', { name: 'flat', nullable: false, default: false })
-    flatFile: boolean = false;
+    flatFile = false;
 
     @Column('integer', { name: 'stripe_count', nullable: false, default: 1 })
-    stripeCount: number = 1;
+    stripeCount = 1;
 
     @Column('text', { nullable: true, default: null })
     stripes: string | null = null;
 
     @Column('integer', { name: 'name_hash', nullable: true, default: 0 })
-    nameHash: number = 0;
+    nameHash = 0;
 
     @Column('integer', { nullable: false, default: 0 })
-    version: number = 0;
+    version = 0;
 
     @Column('text', { name: 'data_state', nullable: false })
     state: FileState;

--- a/src/db/group-index.entity.ts
+++ b/src/db/group-index.entity.ts
@@ -1,19 +1,33 @@
-import { Column, Entity, Index, JoinColumn, ManyToOne, OneToMany, PrimaryColumn } from 'typeorm';
+import {
+    Column,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    OneToMany,
+    PrimaryColumn,
+} from 'typeorm';
 import { FileIndexEntity } from './file-index.entity';
 import { ArchiveIndexEntity } from './archive-index.entity';
 import { IndexEntity } from './index-entity';
 import { StoreIndexEntity } from './store-index.entity';
 import type { FileState } from '../file-state';
 
-
 @Entity('group_index')
-@Index('group_identifier', [ 'key', 'gameBuild', 'archiveKey' ], { unique: true })
+@Index('group_identifier', ['key', 'gameBuild', 'archiveKey'], { unique: true })
 export class GroupIndexEntity extends IndexEntity {
-
-    @PrimaryColumn('text', { name: 'game_build', nullable: false, unique: false })
+    @PrimaryColumn('text', {
+        name: 'game_build',
+        nullable: false,
+        unique: false,
+    })
     gameBuild: string;
 
-    @PrimaryColumn('integer', { name: 'archive_key', unique: false, nullable: false })
+    @PrimaryColumn('integer', {
+        name: 'archive_key',
+        unique: false,
+        nullable: false,
+    })
     archiveKey: number;
 
     @Column('boolean', { name: 'flat', nullable: false, default: false })
@@ -34,21 +48,29 @@ export class GroupIndexEntity extends IndexEntity {
     @Column('text', { name: 'data_state', nullable: false })
     state: FileState;
 
-    @ManyToOne(() => StoreIndexEntity, async store => store.groups,
-        { primary: true, onDelete: 'CASCADE' })
+    @ManyToOne(
+        () => StoreIndexEntity,
+        async (store) => store.groups,
+        { primary: true, onDelete: 'CASCADE' },
+    )
     @JoinColumn({ name: 'game_build', referencedColumnName: 'gameBuild' })
     store: StoreIndexEntity;
 
-    @ManyToOne(() => ArchiveIndexEntity, async archive => archive.groups,
-        { primary: true, onDelete: 'CASCADE' })
+    @ManyToOne(
+        () => ArchiveIndexEntity,
+        async (archive) => archive.groups,
+        { primary: true, onDelete: 'CASCADE' },
+    )
     @JoinColumn([
         { name: 'archive_key', referencedColumnName: 'key' },
-        { name: 'game_build', referencedColumnName: 'gameBuild' }
+        { name: 'game_build', referencedColumnName: 'gameBuild' },
     ])
     archive: ArchiveIndexEntity;
 
-    @OneToMany(() => FileIndexEntity, fileIndex => fileIndex.group,
-        { cascade: true, lazy: true })
+    @OneToMany(
+        () => FileIndexEntity,
+        (fileIndex) => fileIndex.group,
+        { cascade: true, lazy: true },
+    )
     files: Promise<FileIndexEntity[]> | FileIndexEntity[];
-
 }

--- a/src/db/index-entity.ts
+++ b/src/db/index-entity.ts
@@ -1,5 +1,5 @@
 import { Column, CreateDateColumn, PrimaryColumn, UpdateDateColumn } from 'typeorm';
-import { FileState } from '../index';
+import type { FileState } from '../index';
 
 
 export abstract class IndexEntity {
@@ -11,7 +11,7 @@ export abstract class IndexEntity {
     name: string | null = null;
 
     @Column('integer', { nullable: false, default: 0 })
-    size: number = 0;
+    size = 0;
 
     @Column('integer', { nullable: true, default: null })
     crc32: number | null = null;
@@ -28,4 +28,5 @@ export abstract class IndexEntity {
     @UpdateDateColumn()
     updated: Date;
 
+    state: FileState;
 }

--- a/src/db/index-entity.ts
+++ b/src/db/index-entity.ts
@@ -1,9 +1,12 @@
-import { Column, CreateDateColumn, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+import {
+    Column,
+    CreateDateColumn,
+    PrimaryColumn,
+    UpdateDateColumn,
+} from 'typeorm';
 import type { FileState } from '../index';
 
-
 export abstract class IndexEntity {
-
     @PrimaryColumn('integer', { nullable: false, unique: false })
     key: number;
 

--- a/src/db/index-service.ts
+++ b/src/db/index-service.ts
@@ -1,10 +1,10 @@
-import { join } from 'path';
-import { existsSync, mkdirSync } from 'graceful-fs';
-import { Connection, createConnection, Repository } from 'typeorm';
+import { join } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
+import { type Connection, createConnection, type Repository } from 'typeorm';
 
 import { logger } from '@runejs/common';
 
-import { Archive, ArchiveFormat, FileState, FlatFile, Group, IndexedFile, IndexEntity, Store } from '../index';
+import { Archive, ArchiveFormat, FileState, FlatFile, Group, type IndexedFile, type IndexEntity, type Store } from '../index';
 import { ArchiveIndexEntity, FileIndexEntity, GroupIndexEntity, StoreIndexEntity } from './index';
 
 
@@ -61,14 +61,17 @@ export class IndexService {
         }
 
         if(!this.connection.isConnected) {
-            logger.error(`The index database connection was closed prematurely.`);
+            logger.error('The index database connection was closed prematurely.');
             return null;
         }
 
         storeIndex.data = this.store.data?.toNodeBuffer() || null;
 
+        // biome-ignore lint/performance/noDelete: Legacy
         delete storeIndex.archives;
+        // biome-ignore lint/performance/noDelete: Legacy
         delete storeIndex.groups;
+        // biome-ignore lint/performance/noDelete: Legacy
         delete storeIndex.files;
 
         let savedIndex: StoreIndexEntity;
@@ -79,7 +82,7 @@ export class IndexService {
             }, storeIndex);
 
             if(!updateResult?.affected) {
-                logger.error(`Main store entity update failed.`);
+                logger.error('Main store entity update failed.');
                 return null;
             }
 
@@ -147,7 +150,7 @@ export class IndexService {
             }
         });
 
-        let affected;
+        let affected: number;
 
         if(existingIndex) {
             const { name, size, version, sha256, crc32, data, state } = archiveIndex;
@@ -159,6 +162,7 @@ export class IndexService {
             existingIndex.data = data;
             existingIndex.state = state;
 
+            // biome-ignore lint/performance/noDelete: Legacy
             delete existingIndex.groups;
 
             const result = await this.archiveRepo.update({
@@ -168,6 +172,7 @@ export class IndexService {
 
             affected = result?.affected || 0;
         } else {
+            // biome-ignore lint/performance/noDelete: Legacy
             delete archiveIndex.groups;
 
             const result = await this.archiveRepo.insert(archiveIndex);
@@ -240,10 +245,11 @@ export class IndexService {
         const groupIndexes = groups.filter(group => this.entityModified(group))
             .map(group => this.validateGroup(group));
 
+        // biome-ignore lint/performance/noDelete: Legacy
         groupIndexes.forEach(i => delete i.files);
 
         if(!groupIndexes.length) {
-            logger.info(`No groups were modified.`);
+            logger.info('No groups were modified.');
         } else {
             await this.groupRepo.save(groupIndexes, {
                 chunk: CHUNK_SIZE, reload: false
@@ -276,7 +282,7 @@ export class IndexService {
                     key: 'ASC'
                 }
             }) || [];
-        } else {
+        }
             // Return all files for the specified group
 
             return await this.fileRepo.find({
@@ -289,7 +295,6 @@ export class IndexService {
                     key: 'ASC'
                 }
             }) || [];
-        }
     }
 
     public validateFile(file: FlatFile | Partial<FlatFile>): FileIndexEntity {
@@ -326,7 +331,7 @@ export class IndexService {
             .map(file => this.validateFile(file));
 
         if(!flatFileIndexes.length) {
-            logger.info(`No flat files were modified.`);
+            logger.info('No flat files were modified.');
         } else {
             logger.info(`${flatFileIndexes.length} flat files were modified.`);
             await this.fileRepo.save(flatFileIndexes, {

--- a/src/db/index-service.ts
+++ b/src/db/index-service.ts
@@ -4,15 +4,26 @@ import { type Connection, createConnection, type Repository } from 'typeorm';
 
 import { logger } from '@runejs/common';
 
-import { Archive, ArchiveFormat, FileState, FlatFile, Group, type IndexedFile, type IndexEntity, type Store } from '../index';
-import { ArchiveIndexEntity, FileIndexEntity, GroupIndexEntity, StoreIndexEntity } from './index';
-
+import {
+    Archive,
+    ArchiveFormat,
+    FileState,
+    FlatFile,
+    Group,
+    type IndexedFile,
+    type IndexEntity,
+    type Store,
+} from '../index';
+import {
+    ArchiveIndexEntity,
+    FileIndexEntity,
+    GroupIndexEntity,
+    StoreIndexEntity,
+} from './index';
 
 const CHUNK_SIZE = 300; // 250
 
-
 export class IndexService {
-
     public readonly store: Store;
 
     private connection: Connection;
@@ -24,44 +35,53 @@ export class IndexService {
     public async load(): Promise<void> {
         const indexPath = join(this.store.path, 'indexes');
 
-        if(!existsSync(indexPath)) {
+        if (!existsSync(indexPath)) {
             mkdirSync(indexPath, { recursive: true });
         }
 
         this.connection = await createConnection({
             type: 'better-sqlite3',
             database: join(indexPath, `index_${this.store.gameBuild}.sqlite3`),
-            entities: [ StoreIndexEntity, ArchiveIndexEntity, GroupIndexEntity, FileIndexEntity ],
+            entities: [
+                StoreIndexEntity,
+                ArchiveIndexEntity,
+                GroupIndexEntity,
+                FileIndexEntity,
+            ],
             synchronize: true,
-            logging: [ 'error', 'warn' ],
+            logging: ['error', 'warn'],
             // logging: 'all',
-            name: 'index-service'
+            name: 'index-service',
         });
     }
 
     public async getStoreIndex(): Promise<StoreIndexEntity | null> {
-        return await this.storeRepo.findOne({
-            where: {
-                gameBuild: this.store.gameBuild
-            }
-        }) || null;
+        return (
+            (await this.storeRepo.findOne({
+                where: {
+                    gameBuild: this.store.gameBuild,
+                },
+            })) || null
+        );
     }
 
     public async saveStoreIndex(): Promise<StoreIndexEntity | null> {
         let storeIndex = await this.getStoreIndex();
         let update = true;
 
-        if(!storeIndex) {
+        if (!storeIndex) {
             storeIndex = new StoreIndexEntity();
             update = false;
         }
 
-        if(!storeIndex.gameBuild) {
+        if (!storeIndex.gameBuild) {
             storeIndex.gameBuild = this.store.gameBuild;
         }
 
-        if(!this.connection.isConnected) {
-            logger.error('The index database connection was closed prematurely.');
+        if (!this.connection.isConnected) {
+            logger.error(
+                'The index database connection was closed prematurely.',
+            );
             return null;
         }
 
@@ -76,12 +96,15 @@ export class IndexService {
 
         let savedIndex: StoreIndexEntity;
 
-        if(update) {
-            const updateResult = await this.storeRepo.update({
-                gameBuild: this.store.gameBuild
-            }, storeIndex);
+        if (update) {
+            const updateResult = await this.storeRepo.update(
+                {
+                    gameBuild: this.store.gameBuild,
+                },
+                storeIndex,
+            );
 
-            if(!updateResult?.affected) {
+            if (!updateResult?.affected) {
                 logger.error('Main store entity update failed.');
                 return null;
             }
@@ -91,7 +114,7 @@ export class IndexService {
             savedIndex = await this.storeRepo.save(storeIndex);
         }
 
-        if(savedIndex?.gameBuild !== this.store.gameBuild) {
+        if (savedIndex?.gameBuild !== this.store.gameBuild) {
             logger.error(`Error saving store index ${this.store.gameBuild}.`);
             return null;
         }
@@ -101,32 +124,47 @@ export class IndexService {
         return savedIndex;
     }
 
-    public async getArchiveIndex(archive: Archive): Promise<ArchiveIndexEntity | null>;
-    public async getArchiveIndex(archiveKey: number): Promise<ArchiveIndexEntity | null>;
-    public async getArchiveIndex(archive: Archive | number): Promise<ArchiveIndexEntity | null> {
+    public async getArchiveIndex(
+        archive: Archive,
+    ): Promise<ArchiveIndexEntity | null>;
+    public async getArchiveIndex(
+        archiveKey: number,
+    ): Promise<ArchiveIndexEntity | null>;
+    public async getArchiveIndex(
+        archive: Archive | number,
+    ): Promise<ArchiveIndexEntity | null> {
         const key = typeof archive === 'number' ? archive : archive.numericKey;
-        return await this.archiveRepo.findOne({
-            where: {
-                key, gameBuild: this.store.gameBuild
-            },
-            relations: [ 'groups' ]
-        }) || null;
+        return (
+            (await this.archiveRepo.findOne({
+                where: {
+                    key,
+                    gameBuild: this.store.gameBuild,
+                },
+                relations: ['groups'],
+            })) || null
+        );
     }
 
     public async getArchiveIndexes(): Promise<ArchiveIndexEntity[]> {
-        return await this.archiveRepo.find({
-            where: {
-                gameBuild: this.store.gameBuild
-            },
-            order: {
-                key: 'ASC'
-            }
-        }) || [];
+        return (
+            (await this.archiveRepo.find({
+                where: {
+                    gameBuild: this.store.gameBuild,
+                },
+                order: {
+                    key: 'ASC',
+                },
+            })) || []
+        );
     }
 
-    public validateArchive(archive: Archive | Partial<Archive>): ArchiveIndexEntity {
-        const archiveIndex: ArchiveIndexEntity = archive.index ? archive.index : new ArchiveIndexEntity();
-        if(!archive.index) {
+    public validateArchive(
+        archive: Archive | Partial<Archive>,
+    ): ArchiveIndexEntity {
+        const archiveIndex: ArchiveIndexEntity = archive.index
+            ? archive.index
+            : new ArchiveIndexEntity();
+        if (!archive.index) {
             archive.index = archiveIndex;
         }
 
@@ -141,19 +179,22 @@ export class IndexService {
         return archiveIndex;
     }
 
-    public async saveArchiveIndex(archive: Archive): Promise<ArchiveIndexEntity> {
+    public async saveArchiveIndex(
+        archive: Archive,
+    ): Promise<ArchiveIndexEntity> {
         const archiveIndex = archive.index;
         const existingIndex = await this.archiveRepo.findOne({
             where: {
                 key: archiveIndex.key,
-                gameBuild: this.store.gameBuild
-            }
+                gameBuild: this.store.gameBuild,
+            },
         });
 
         let affected: number;
 
-        if(existingIndex) {
-            const { name, size, version, sha256, crc32, data, state } = archiveIndex;
+        if (existingIndex) {
+            const { name, size, version, sha256, crc32, data, state } =
+                archiveIndex;
             existingIndex.name = name;
             existingIndex.size = size;
             existingIndex.version = version;
@@ -165,10 +206,13 @@ export class IndexService {
             // biome-ignore lint/performance/noDelete: Legacy
             delete existingIndex.groups;
 
-            const result = await this.archiveRepo.update({
-                key: archiveIndex.key,
-                gameBuild: this.store.gameBuild
-            }, existingIndex);
+            const result = await this.archiveRepo.update(
+                {
+                    key: archiveIndex.key,
+                    gameBuild: this.store.gameBuild,
+                },
+                existingIndex,
+            );
 
             affected = result?.affected || 0;
         } else {
@@ -179,8 +223,10 @@ export class IndexService {
             affected = result?.identifiers?.length || 0;
         }
 
-        if(!affected) {
-            logger.error(`Error updating archive ${archiveIndex.name} database index.`);
+        if (!affected) {
+            logger.error(
+                `Error updating archive ${archiveIndex.name} database index.`,
+            );
         } else {
             logger.info(`Archive ${archiveIndex.name} database index saved.`);
         }
@@ -189,36 +235,52 @@ export class IndexService {
     }
 
     public async getGroupIndex(group: Group): Promise<GroupIndexEntity | null>;
-    public async getGroupIndex(groupKey: number, archiveKey: number): Promise<GroupIndexEntity | null>;
-    public async getGroupIndex(group: Group | number, archive?: number): Promise<GroupIndexEntity | null> {
+    public async getGroupIndex(
+        groupKey: number,
+        archiveKey: number,
+    ): Promise<GroupIndexEntity | null>;
+    public async getGroupIndex(
+        group: Group | number,
+        archive?: number,
+    ): Promise<GroupIndexEntity | null> {
         const key = typeof group === 'number' ? group : group.numericKey;
-        const archiveKey = typeof group === 'number' ? archive : group.archive.numericKey;
+        const archiveKey =
+            typeof group === 'number' ? archive : group.archive.numericKey;
 
-        return await this.groupRepo.findOne({
-            where: {
-                key, archiveKey,
-                gameBuild: this.store.gameBuild
-            }
-        }) || null;
+        return (
+            (await this.groupRepo.findOne({
+                where: {
+                    key,
+                    archiveKey,
+                    gameBuild: this.store.gameBuild,
+                },
+            })) || null
+        );
     }
 
-    public async getGroupIndexes(archive: ArchiveIndexEntity): Promise<GroupIndexEntity[]> {
-        return await this.groupRepo.find({
-            where: {
-                archiveKey: archive.key,
-                gameBuild: this.store.gameBuild
-            },
-            order: {
-                key: 'ASC'
-            }
-        }) || [];
+    public async getGroupIndexes(
+        archive: ArchiveIndexEntity,
+    ): Promise<GroupIndexEntity[]> {
+        return (
+            (await this.groupRepo.find({
+                where: {
+                    archiveKey: archive.key,
+                    gameBuild: this.store.gameBuild,
+                },
+                order: {
+                    key: 'ASC',
+                },
+            })) || []
+        );
     }
 
     public validateGroup(group: Group | Partial<Group>): GroupIndexEntity {
         const { stripes, archive, files } = group;
 
-        const groupIndex: GroupIndexEntity = group.index ? group.index : new GroupIndexEntity();
-        if(!group.index) {
+        const groupIndex: GroupIndexEntity = group.index
+            ? group.index
+            : new GroupIndexEntity();
+        if (!group.index) {
             group.index = groupIndex;
         }
 
@@ -229,79 +291,91 @@ export class IndexService {
         groupIndex.state = group.state;
         groupIndex.stripes = stripes?.length ? stripes.join(',') : null;
         groupIndex.stripeCount = stripes?.length || 1;
-        groupIndex.flatFile = (files?.size === 1 || archive.config.flatten);
+        groupIndex.flatFile = files?.size === 1 || archive.config.flatten;
 
         return groupIndex;
     }
 
     public async saveGroupIndex(group: Group): Promise<void> {
-        if(!this.entityModified(group)) {
+        if (!this.entityModified(group)) {
             return;
         }
         await this.groupRepo.upsert(this.validateGroup(group), []);
     }
 
     public async saveGroupIndexes(groups: Group[]): Promise<void> {
-        const groupIndexes = groups.filter(group => this.entityModified(group))
-            .map(group => this.validateGroup(group));
+        const groupIndexes = groups
+            .filter((group) => this.entityModified(group))
+            .map((group) => this.validateGroup(group));
 
         // biome-ignore lint/performance/noDelete: Legacy
-        groupIndexes.forEach(i => delete i.files);
+        groupIndexes.forEach((i) => delete i.files);
 
-        if(!groupIndexes.length) {
+        if (!groupIndexes.length) {
             logger.info('No groups were modified.');
         } else {
             await this.groupRepo.save(groupIndexes, {
-                chunk: CHUNK_SIZE, reload: false
+                chunk: CHUNK_SIZE,
+                reload: false,
             });
         }
     }
 
     public async getFileIndex(file: FlatFile): Promise<FileIndexEntity | null> {
-        return await this.fileRepo.findOne({
-            where: {
-                key: file.numericKey,
-                groupKey: file.group.numericKey,
-                archiveKey: file.archive.numericKey,
-                gameBuild: this.store.gameBuild
-            }
-        }) || null;
+        return (
+            (await this.fileRepo.findOne({
+                where: {
+                    key: file.numericKey,
+                    groupKey: file.group.numericKey,
+                    archiveKey: file.archive.numericKey,
+                    gameBuild: this.store.gameBuild,
+                },
+            })) || null
+        );
     }
 
-    public async getFileIndexes(archiveOrGroup: ArchiveIndexEntity | GroupIndexEntity): Promise<FileIndexEntity[]> {
-        if(archiveOrGroup instanceof ArchiveIndexEntity) {
+    public async getFileIndexes(
+        archiveOrGroup: ArchiveIndexEntity | GroupIndexEntity,
+    ): Promise<FileIndexEntity[]> {
+        if (archiveOrGroup instanceof ArchiveIndexEntity) {
             // Return all files for the specified archive
 
-            return await this.fileRepo.find({
-                where: {
-                    archiveKey: archiveOrGroup.key,
-                    gameBuild: this.store.gameBuild
-                },
-                order: {
-                    groupKey: 'ASC',
-                    key: 'ASC'
-                }
-            }) || [];
+            return (
+                (await this.fileRepo.find({
+                    where: {
+                        archiveKey: archiveOrGroup.key,
+                        gameBuild: this.store.gameBuild,
+                    },
+                    order: {
+                        groupKey: 'ASC',
+                        key: 'ASC',
+                    },
+                })) || []
+            );
         }
-            // Return all files for the specified group
+        // Return all files for the specified group
 
-            return await this.fileRepo.find({
+        return (
+            (await this.fileRepo.find({
                 where: {
                     groupKey: archiveOrGroup.key,
                     archiveKey: archiveOrGroup.archiveKey,
-                    gameBuild: this.store.gameBuild
+                    gameBuild: this.store.gameBuild,
                 },
                 order: {
-                    key: 'ASC'
-                }
-            }) || [];
+                    key: 'ASC',
+                },
+            })) || []
+        );
     }
 
     public validateFile(file: FlatFile | Partial<FlatFile>): FileIndexEntity {
         const { size, stripes, group, archive } = file;
 
-        const fileIndex: FileIndexEntity = file.index ? file.index : new FileIndexEntity();
-        if(!file.index) {
+        const fileIndex: FileIndexEntity = file.index
+            ? file.index
+            : new FileIndexEntity();
+        if (!file.index) {
             file.index = fileIndex;
         }
 
@@ -320,106 +394,132 @@ export class IndexService {
     }
 
     public async saveFileIndex(file: FlatFile): Promise<void> {
-        if(!this.entityModified(file)) {
+        if (!this.entityModified(file)) {
             return;
         }
         await this.fileRepo.upsert(this.validateFile(file), []);
     }
 
     public async saveFileIndexes(files: FlatFile[]): Promise<void> {
-        const flatFileIndexes = files.filter(file => this.entityModified(file))
-            .map(file => this.validateFile(file));
+        const flatFileIndexes = files
+            .filter((file) => this.entityModified(file))
+            .map((file) => this.validateFile(file));
 
-        if(!flatFileIndexes.length) {
+        if (!flatFileIndexes.length) {
             logger.info('No flat files were modified.');
         } else {
             logger.info(`${flatFileIndexes.length} flat files were modified.`);
             await this.fileRepo.save(flatFileIndexes, {
-                chunk: CHUNK_SIZE, reload: false, transaction: false, listeners: false
+                chunk: CHUNK_SIZE,
+                reload: false,
+                transaction: false,
+                listeners: false,
             });
         }
     }
 
-    public entityModified<T extends IndexEntity>(file: IndexedFile<T> | Partial<IndexedFile<T>>): boolean {
+    public entityModified<T extends IndexEntity>(
+        file: IndexedFile<T> | Partial<IndexedFile<T>>,
+    ): boolean {
         const index = file.index;
 
-        if(file.numericKey !== index.key || file.name !== index.name) {
+        if (file.numericKey !== index.key || file.name !== index.name) {
             return true;
         }
 
-        if((index instanceof GroupIndexEntity || index instanceof FileIndexEntity) &&
-            (file instanceof Group || file instanceof FlatFile)) {
-            if(file.nameHash !== index.nameHash || file.version !== index.version) {
+        if (
+            (index instanceof GroupIndexEntity ||
+                index instanceof FileIndexEntity) &&
+            (file instanceof Group || file instanceof FlatFile)
+        ) {
+            if (
+                file.nameHash !== index.nameHash ||
+                file.version !== index.version
+            ) {
                 return true;
             }
 
-            if(file.archive.numericKey !== index.archiveKey) {
+            if (file.archive.numericKey !== index.archiveKey) {
                 return true;
             }
         }
 
-        if((index instanceof ArchiveIndexEntity || index instanceof GroupIndexEntity) &&
-            (file instanceof Archive || file instanceof Group)) {
-            if(file.state !== index.state) {
+        if (
+            (index instanceof ArchiveIndexEntity ||
+                index instanceof GroupIndexEntity) &&
+            (file instanceof Archive || file instanceof Group)
+        ) {
+            if (file.state !== index.state) {
                 // return true;
             }
         }
 
-        if(index instanceof FileIndexEntity && file instanceof FlatFile) {
-            if(file.group.numericKey !== index.groupKey) {
+        if (index instanceof FileIndexEntity && file instanceof FlatFile) {
+            if (file.group.numericKey !== index.groupKey) {
                 return true;
             }
         }
 
-        return file.size !== index.size || file.crc32 !== index.crc32 || file.sha256 !== index.sha256;
+        return (
+            file.size !== index.size ||
+            file.crc32 !== index.crc32 ||
+            file.sha256 !== index.sha256
+        );
     }
 
-    public updateEntityIndex<T extends IndexEntity>(file: IndexedFile<T> | Partial<IndexedFile<T>>): T {
+    public updateEntityIndex<T extends IndexEntity>(
+        file: IndexedFile<T> | Partial<IndexedFile<T>>,
+    ): T {
         const index = file.index;
 
-        if(!file.name && file.hasNameHash) {
-            file.name = file.hasNameHash ?
-                this.store.findFileName(file.nameHash, String(file.nameHash)) : file.key;
-        } else if(!file.hasNameHash && file.named) {
+        if (!file.name && file.hasNameHash) {
+            file.name = file.hasNameHash
+                ? this.store.findFileName(file.nameHash, String(file.nameHash))
+                : file.key;
+        } else if (!file.hasNameHash && file.named) {
             file.nameHash = this.store.hashFileName(file.name);
         } else {
             file.nameHash = -1;
         }
 
-        if(index instanceof ArchiveIndexEntity || index instanceof GroupIndexEntity || index instanceof FileIndexEntity) {
+        if (
+            index instanceof ArchiveIndexEntity ||
+            index instanceof GroupIndexEntity ||
+            index instanceof FileIndexEntity
+        ) {
             index.version = file.version;
 
-            if(file.modified) {
+            if (file.modified) {
                 index.version = index.version ? index.version + 1 : 1;
             }
         }
 
-        if(index.key === undefined || index.key === null) {
+        if (index.key === undefined || index.key === null) {
             index.key = file.numericKey;
         }
 
-        if(index.name !== file.name) {
+        if (index.name !== file.name) {
             index.name = file.name;
         }
 
         let dataModified = false;
 
-        if(index.size !== file.size) {
+        if (index.size !== file.size) {
             index.size = file.size;
             dataModified = true;
         }
 
-        if(index.crc32 !== file.crc32) {
+        if (index.crc32 !== file.crc32) {
             index.crc32 = file.crc32;
             dataModified = true;
         }
 
-        if(index.sha256 !== file.sha256) {
+        if (index.sha256 !== file.sha256) {
             index.sha256 = file.sha256;
             dataModified = true;
         }
 
-        if(dataModified || !index.data?.length) {
+        if (dataModified || !index.data?.length) {
             index.data = file.data?.length ? Buffer.from(file.data) : null;
         }
 
@@ -445,5 +545,4 @@ export class IndexService {
     public get fileRepo(): Repository<FileIndexEntity> {
         return this.connection.getRepository(FileIndexEntity);
     }
-
 }

--- a/src/db/store-index.entity.ts
+++ b/src/db/store-index.entity.ts
@@ -1,23 +1,44 @@
-import { Column, CreateDateColumn, Entity, OneToMany, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    OneToMany,
+    PrimaryColumn,
+    UpdateDateColumn,
+} from 'typeorm';
 
 import { ArchiveIndexEntity } from './archive-index.entity';
 import { GroupIndexEntity } from './group-index.entity';
 import { FileIndexEntity } from './file-index.entity';
 
-
 @Entity('store_index')
 export class StoreIndexEntity {
-
-    @PrimaryColumn('text', { name: 'game_build', nullable: false, unique: true })
+    @PrimaryColumn('text', {
+        name: 'game_build',
+        nullable: false,
+        unique: true,
+    })
     gameBuild: string;
 
-    @OneToMany(() => ArchiveIndexEntity, archive => archive.store, { lazy: true })
+    @OneToMany(
+        () => ArchiveIndexEntity,
+        (archive) => archive.store,
+        { lazy: true },
+    )
     archives: Promise<ArchiveIndexEntity[]> | ArchiveIndexEntity[];
 
-    @OneToMany(() => GroupIndexEntity, group => group.store, { lazy: true })
+    @OneToMany(
+        () => GroupIndexEntity,
+        (group) => group.store,
+        { lazy: true },
+    )
     groups: Promise<GroupIndexEntity[]> | GroupIndexEntity[];
 
-    @OneToMany(() => FileIndexEntity, file => file.store, { lazy: true })
+    @OneToMany(
+        () => FileIndexEntity,
+        (file) => file.store,
+        { lazy: true },
+    )
     files: Promise<FileIndexEntity[]> | FileIndexEntity[];
 
     @Column('blob', { name: 'data', nullable: true, default: null })
@@ -28,5 +49,4 @@ export class StoreIndexEntity {
 
     @UpdateDateColumn()
     updated: Date;
-
 }

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -1,5 +1,5 @@
 import { Store } from './index';
-import { join } from 'path';
+import { join } from 'node:path';
 
 
 const store = Store.create('435');

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -1,6 +1,4 @@
 import { Store } from './index';
 import { join } from 'node:path';
 
-
 const store = Store.create('435');
-

--- a/src/file-state.ts
+++ b/src/file-state.ts
@@ -50,5 +50,5 @@ export enum FileState {
     /**
      * The file was not found.
      */
-    missing = 'missing'
+    missing = 'missing',
 }

--- a/src/flat-file.ts
+++ b/src/flat-file.ts
@@ -7,37 +7,42 @@ import { type FileBreadcrumb, IndexedFile } from './indexed-file';
 import { FileState } from './file-state';
 import { isSet } from './util';
 
-
 export class FlatFile extends IndexedFile<FileIndexEntity> {
-
     public stripes: number[] = [];
     public stripeCount = 1;
 
-    public constructor(index: FileIndexEntity, breadcrumb?: Partial<FileBreadcrumb>) {
+    public constructor(
+        index: FileIndexEntity,
+        breadcrumb?: Partial<FileBreadcrumb>,
+    ) {
         super(index, breadcrumb);
 
-        if(isSet(index.stripes)) {
-            this.stripes = index.stripes.split(',').map(n => Number(n));
+        if (isSet(index.stripes)) {
+            this.stripes = index.stripes.split(',').map((n) => Number(n));
         }
-        if(isSet(index.stripeCount)) {
+        if (isSet(index.stripeCount)) {
             this.stripeCount = index.stripeCount;
         }
-        if(isSet(index.version)) {
+        if (isSet(index.version)) {
             this.version = index.version;
         }
-        if(isSet(index.nameHash)) {
+        if (isSet(index.nameHash)) {
             this.nameHash = index.nameHash;
         }
     }
 
-    public override read(compress = false): ByteBuffer | null | Promise<ByteBuffer | null> {
-        if(!this.group) {
-            throw new Error(`Flat file ${this.key} could not be read as it does not belong to any known groups.`);
+    public override read(
+        compress = false,
+    ): ByteBuffer | null | Promise<ByteBuffer | null> {
+        if (!this.group) {
+            throw new Error(
+                `Flat file ${this.key} could not be read as it does not belong to any known groups.`,
+            );
         }
 
         const filePath = this.path;
 
-        if(!existsSync(filePath)) {
+        if (!existsSync(filePath)) {
             logger.error(`File not found: ${filePath}`);
             this.setState(FileState.missing);
             return null;
@@ -47,44 +52,52 @@ export class FlatFile extends IndexedFile<FileIndexEntity> {
 
         try {
             data = readFileSync(filePath);
-        } catch(error) {
-            logger.error(`Error reading file ${this.name || this.key } at ${filePath}:`, error);
+        } catch (error) {
+            logger.error(
+                `Error reading file ${this.name || this.key} at ${filePath}:`,
+                error,
+            );
             data = null;
         }
 
-        if(!data) {
+        if (!data) {
             this.setState(FileState.corrupt);
-        } else if(!data.length) {
+        } else if (!data.length) {
             this.setState(FileState.empty);
         } else {
             const fileData = new ByteBuffer(data);
 
-            if(!this.name) {
+            if (!this.name) {
                 this.name = this.group.name || this.key;
             }
 
-            if(!this.nameHash) {
+            if (!this.nameHash) {
                 this.nameHash = this.group.nameHash || undefined;
             }
 
-            if(!this.stripes) {
+            if (!this.stripes) {
                 const stripeStr = this.index.stripes;
-                if(stripeStr?.length) {
-                    this.stripes = stripeStr.split(',')?.map(s => Number(s)) ?? undefined;
+                if (stripeStr?.length) {
+                    this.stripes =
+                        stripeStr.split(',')?.map((s) => Number(s)) ??
+                        undefined;
                 }
             }
 
-            if(!this.crc32) {
+            if (!this.crc32) {
                 this.crc32 = this.index.crc32 ?? 0;
             }
 
-            if(!this.sha256) {
+            if (!this.sha256) {
                 this.sha256 = this.index.sha256 ?? undefined;
             }
 
             this.setData(fileData, FileState.raw);
 
-            if(this.size !== this.index.size || this.sha256 !== this.generateSha256()) {
+            if (
+                this.size !== this.index.size ||
+                this.sha256 !== this.generateSha256()
+            ) {
                 this._modified = true;
             }
 
@@ -97,26 +110,29 @@ export class FlatFile extends IndexedFile<FileIndexEntity> {
 
     public override get path(): string {
         const groupPath = this.group?.path || null;
-        if(!groupPath) {
-            throw new Error(`Error generating file path; File ${this.key} has not been added to a group.`);
+        if (!groupPath) {
+            throw new Error(
+                `Error generating file path; File ${this.key} has not been added to a group.`,
+            );
         }
 
-        if(this.group.fileCount === 1 || this.archive?.config?.flatten) {
+        if (this.group.fileCount === 1 || this.archive?.config?.flatten) {
             return groupPath + this.type;
         }
-            return join(groupPath, String(this.name || this.key)) + this.type;
+        return join(groupPath, String(this.name || this.key)) + this.type;
     }
 
     public override get outputPath(): string {
         const groupOutputPath = this.group?.outputPath || null;
-        if(!groupOutputPath) {
-            throw new Error(`Error generating file output path; File ${this.key} has not been added to a group.`);
+        if (!groupOutputPath) {
+            throw new Error(
+                `Error generating file output path; File ${this.key} has not been added to a group.`,
+            );
         }
 
-        if(this.group.fileCount === 1 || this.archive?.config?.flatten) {
+        if (this.group.fileCount === 1 || this.archive?.config?.flatten) {
             return groupOutputPath + this.type;
         }
-            return join(groupOutputPath, String(this.name || this.key) + this.type);
+        return join(groupOutputPath, String(this.name || this.key) + this.type);
     }
-
 }

--- a/src/flat-file.ts
+++ b/src/flat-file.ts
@@ -1,9 +1,9 @@
-import { join } from 'path';
-import { existsSync, readFileSync } from 'graceful-fs';
+import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
 import { ByteBuffer, logger } from '@runejs/common';
 
-import { FileIndexEntity } from './db';
-import { FileBreadcrumb, IndexedFile } from './indexed-file';
+import type { FileIndexEntity } from './db';
+import { type FileBreadcrumb, IndexedFile } from './indexed-file';
 import { FileState } from './file-state';
 import { isSet } from './util';
 
@@ -11,7 +11,7 @@ import { isSet } from './util';
 export class FlatFile extends IndexedFile<FileIndexEntity> {
 
     public stripes: number[] = [];
-    public stripeCount: number = 1;
+    public stripeCount = 1;
 
     public constructor(index: FileIndexEntity, breadcrumb?: Partial<FileBreadcrumb>) {
         super(index, breadcrumb);
@@ -30,7 +30,7 @@ export class FlatFile extends IndexedFile<FileIndexEntity> {
         }
     }
 
-    public override read(compress: boolean = false): ByteBuffer | null | Promise<ByteBuffer | null> {
+    public override read(compress = false): ByteBuffer | null | Promise<ByteBuffer | null> {
         if(!this.group) {
             throw new Error(`Flat file ${this.key} could not be read as it does not belong to any known groups.`);
         }
@@ -103,9 +103,8 @@ export class FlatFile extends IndexedFile<FileIndexEntity> {
 
         if(this.group.fileCount === 1 || this.archive?.config?.flatten) {
             return groupPath + this.type;
-        } else {
-            return join(groupPath, String(this.name || this.key)) + this.type;
         }
+            return join(groupPath, String(this.name || this.key)) + this.type;
     }
 
     public override get outputPath(): string {
@@ -116,9 +115,8 @@ export class FlatFile extends IndexedFile<FileIndexEntity> {
 
         if(this.group.fileCount === 1 || this.archive?.config?.flatten) {
             return groupOutputPath + this.type;
-        } else {
-            return join(groupOutputPath, String(this.name || this.key) + this.type);
         }
+            return join(groupOutputPath, String(this.name || this.key) + this.type);
     }
 
 }

--- a/src/group.ts
+++ b/src/group.ts
@@ -8,9 +8,7 @@ import { type FileBreadcrumb, IndexedFile } from './indexed-file';
 import { FileState } from './file-state';
 import { isSet } from './util';
 
-
 export class Group extends IndexedFile<GroupIndexEntity> {
-
     public readonly files: Map<string, FlatFile> = new Map<string, FlatFile>();
     public readonly fileSizes: Map<string, number> = new Map<string, number>();
 
@@ -19,26 +17,31 @@ export class Group extends IndexedFile<GroupIndexEntity> {
 
     private _fileCount = 0;
 
-    public constructor(index: GroupIndexEntity, breadcrumb?: Partial<FileBreadcrumb>) {
+    public constructor(
+        index: GroupIndexEntity,
+        breadcrumb?: Partial<FileBreadcrumb>,
+    ) {
         super(index, breadcrumb);
 
-        if(isSet(index.stripes)) {
-            this.stripes = index.stripes.split(',').map(n => Number(n));
+        if (isSet(index.stripes)) {
+            this.stripes = index.stripes.split(',').map((n) => Number(n));
         }
-        if(isSet(index.stripeCount)) {
+        if (isSet(index.stripeCount)) {
             this.stripeCount = index.stripeCount;
         }
-        if(isSet(index.version)) {
+        if (isSet(index.version)) {
             this.version = index.version;
         }
-        if(isSet(index.nameHash)) {
+        if (isSet(index.nameHash)) {
             this.nameHash = index.nameHash;
         }
 
-        if(this.archive.config.groupNames) {
+        if (this.archive.config.groupNames) {
             const nameEntries = Object.entries(this.archive.config.groupNames);
-            const namedEntry = nameEntries.find(entry => entry[1] === this.numericKey) || null;
-            if(namedEntry) {
+            const namedEntry =
+                nameEntries.find((entry) => entry[1] === this.numericKey) ||
+                null;
+            if (namedEntry) {
                 this.name = namedEntry[0];
             }
         }
@@ -48,7 +51,7 @@ export class Group extends IndexedFile<GroupIndexEntity> {
         this.unpack();
         this.decompress();
 
-        if(this._fileCount === 1) {
+        if (this._fileCount === 1) {
             const flatFile: FlatFile = Array.from(this.files.values())[0];
             flatFile.name = this.name;
             flatFile.nameHash = this.nameHash;
@@ -59,34 +62,37 @@ export class Group extends IndexedFile<GroupIndexEntity> {
         } else {
             const dataLength = this._data?.length || 0;
 
-            if(!dataLength || dataLength <= 0) {
+            if (!dataLength || dataLength <= 0) {
                 logger.error(`Error decoding group ${this.key}`);
                 return null;
             }
 
-            this._data.readerIndex = (dataLength - 1); // EOF
+            this._data.readerIndex = dataLength - 1; // EOF
 
             this.stripeCount = this._data.get('byte', 'unsigned');
 
-            this._data.readerIndex = (dataLength - 1 - this.stripeCount * this.files.size * 4); // Stripe data footer
+            this._data.readerIndex =
+                dataLength - 1 - this.stripeCount * this.files.size * 4; // Stripe data footer
 
-            if(this._data.readerIndex < 0) {
-                logger.error(`Invalid reader index of ${this._data.readerIndex} for group ${this.archive.name}:${this.key}.`);
+            if (this._data.readerIndex < 0) {
+                logger.error(
+                    `Invalid reader index of ${this._data.readerIndex} for group ${this.archive.name}:${this.key}.`,
+                );
                 return null;
             }
 
-            for(let stripe = 0; stripe < this.stripeCount; stripe++) {
+            for (let stripe = 0; stripe < this.stripeCount; stripe++) {
                 let currentLength = 0;
-                for(const [ fileIndex, file ] of this.files) {
+                for (const [fileIndex, file] of this.files) {
                     const delta = this._data.get('int');
                     currentLength += delta;
 
-                    if(!file.stripes?.length) {
+                    if (!file.stripes?.length) {
                         file.stripes = new Array(this.stripeCount);
                     }
 
                     let size = 0;
-                    if(!this.fileSizes.has(fileIndex)) {
+                    if (!this.fileSizes.has(fileIndex)) {
                         this.fileSizes.set(fileIndex, 0);
                     } else {
                         size = this.fileSizes.get(fileIndex);
@@ -97,7 +103,7 @@ export class Group extends IndexedFile<GroupIndexEntity> {
                 }
             }
 
-            for(const [ fileIndex, file ] of this.files) {
+            for (const [fileIndex, file] of this.files) {
                 const fileSize = this.fileSizes.get(fileIndex) || 0;
                 file.setData(new ByteBuffer(fileSize), FileState.raw);
                 file.size = fileSize;
@@ -105,17 +111,27 @@ export class Group extends IndexedFile<GroupIndexEntity> {
 
             this._data.readerIndex = 0;
 
-            for(let stripe = 0; stripe < this.stripeCount; stripe++) {
-                for(const [ , file ] of this.files) {
+            for (let stripe = 0; stripe < this.stripeCount; stripe++) {
+                for (const [, file] of this.files) {
                     let stripeLength = file.stripes[stripe];
-                    let sourceEnd: number = this._data.readerIndex + stripeLength;
+                    let sourceEnd: number =
+                        this._data.readerIndex + stripeLength;
 
-                    if(this._data.readerIndex + stripeLength >= this._data.length) {
+                    if (
+                        this._data.readerIndex + stripeLength >=
+                        this._data.length
+                    ) {
                         sourceEnd = this._data.length;
-                        stripeLength = (this._data.readerIndex + stripeLength) - this._data.length;
+                        stripeLength =
+                            this._data.readerIndex +
+                            stripeLength -
+                            this._data.length;
                     }
 
-                    const stripeData = this._data.getSlice(this._data.readerIndex, stripeLength);
+                    const stripeData = this._data.getSlice(
+                        this._data.readerIndex,
+                        stripeLength,
+                    );
 
                     file.data.putBytes(stripeData);
 
@@ -123,7 +139,7 @@ export class Group extends IndexedFile<GroupIndexEntity> {
                 }
             }
 
-            this.files.forEach(file => file.generateSha256());
+            this.files.forEach((file) => file.generateSha256());
         }
 
         this.setData(this._data, FileState.raw);
@@ -133,52 +149,61 @@ export class Group extends IndexedFile<GroupIndexEntity> {
 
     public override encode(): ByteBuffer | null {
         // Single-file group
-        if(this._fileCount === 1) {
+        if (this._fileCount === 1) {
             const flatFile = Array.from(this.files.values())[0];
-            this.setData(flatFile.data ?? new ByteBuffer([]), FileState.encoded);
+            this.setData(
+                flatFile.data ?? new ByteBuffer([]),
+                FileState.encoded,
+            );
             return this._data;
         }
 
         // Multi-file group
-        const fileData: ByteBuffer[] = Array.from(this.files.values()).map(file => file?.data ?? new ByteBuffer(0));
-        const fileSizes = fileData.map(data => data.length);
+        const fileData: ByteBuffer[] = Array.from(this.files.values()).map(
+            (file) => file?.data ?? new ByteBuffer(0),
+        );
+        const fileSizes = fileData.map((data) => data.length);
         const fileCount = this._fileCount;
         const stripeCount = this.stripes?.length ?? 1;
 
-        if(!stripeCount) {
+        if (!stripeCount) {
             return null;
         }
 
         // Size of all individual files + 1 int per file containing it's size
         // + 1 at the end for the total group stripe count
-        const groupSize = fileSizes.reduce((a, c) => a + c) + (stripeCount * fileCount * 4) + 1;
+        const groupSize =
+            fileSizes.reduce((a, c) => a + c) + stripeCount * fileCount * 4 + 1;
         const groupBuffer = new ByteBuffer(groupSize);
 
-        fileData.forEach(data => {
+        fileData.forEach((data) => {
             data.readerIndex = 0;
         });
 
         // Write file content stripes
-        for(let stripe = 0; stripe < stripeCount; stripe++) {
-            for(const [ , file ] of this.files) {
-                if(!file?.data?.length) {
+        for (let stripe = 0; stripe < stripeCount; stripe++) {
+            for (const [, file] of this.files) {
+                if (!file?.data?.length) {
                     continue;
                 }
 
                 const stripeSize = file.stripes[stripe];
 
-                if(stripeSize) {
-                    const stripeData = file.data.getSlice(file.data.readerIndex, stripeSize);
+                if (stripeSize) {
+                    const stripeData = file.data.getSlice(
+                        file.data.readerIndex,
+                        stripeSize,
+                    );
                     file.data.readerIndex = file.data.readerIndex + stripeSize;
                     groupBuffer.putBytes(stripeData);
                 }
             }
         }
 
-        for(let stripe = 0; stripe < stripeCount; stripe++) {
+        for (let stripe = 0; stripe < stripeCount; stripe++) {
             let prevSize = 0;
-            for(const [ , file ] of this.files) {
-                if(!file?.data?.length) {
+            for (const [, file] of this.files) {
+                if (!file?.data?.length) {
                     continue;
                 }
 
@@ -194,42 +219,69 @@ export class Group extends IndexedFile<GroupIndexEntity> {
         return this._data;
     }
 
-    public override async read(compress = false, readDiskFiles = true): Promise<ByteBuffer | null> {
-        if(!this.index) {
-            logger.error(`Error reading group ${this.name} files: Group is not indexed, please re-index the ` +
-                `${this.archive.name} archive.`);
+    public override async read(
+        compress = false,
+        readDiskFiles = true,
+    ): Promise<ByteBuffer | null> {
+        if (!this.index) {
+            logger.error(
+                `Error reading group ${this.name} files: Group is not indexed, please re-index the ` +
+                    `${this.archive.name} archive.`,
+            );
             return null;
         }
 
-        if(this.index.data?.length) {
+        if (this.index.data?.length) {
             this.setData(this.index.data, FileState.compressed);
         }
 
         let indexedFiles = await this.index.files;
 
-        if(!indexedFiles?.length) {
+        if (!indexedFiles?.length) {
             // Single file indexes are not stored to save on DB space and read/write times
             // So if a group has no children, assume it is a single-file group and create a single index for it
-            const { name, nameHash, version, size, crc32, sha256, stripes, stripeCount, archive, state } = this;
-            indexedFiles = this.index.files = [ this.indexService.validateFile({
-                numericKey: 0, name, nameHash, version, size, crc32, sha256, stripes, stripeCount,
-                group: this, archive
-            }) ];
+            const {
+                name,
+                nameHash,
+                version,
+                size,
+                crc32,
+                sha256,
+                stripes,
+                stripeCount,
+                archive,
+                state,
+            } = this;
+            indexedFiles = this.index.files = [
+                this.indexService.validateFile({
+                    numericKey: 0,
+                    name,
+                    nameHash,
+                    version,
+                    size,
+                    crc32,
+                    sha256,
+                    stripes,
+                    stripeCount,
+                    group: this,
+                    archive,
+                }),
+            ];
         }
 
         let childFileCount = 1;
 
         const groupPath = this.path;
 
-        if(this.archive.versioned) {
+        if (this.archive.versioned) {
             this.version = this.index.version;
         }
 
-        if(existsSync(groupPath) && statSync(groupPath).isDirectory()) {
+        if (existsSync(groupPath) && statSync(groupPath).isDirectory()) {
             childFileCount = readdirSync(groupPath).length ?? 1;
         }
 
-        if(indexedFiles.length !== childFileCount) {
+        if (indexedFiles.length !== childFileCount) {
             this._modified = true;
         }
 
@@ -239,9 +291,11 @@ export class Group extends IndexedFile<GroupIndexEntity> {
         this.fileSizes.clear();
 
         // Load the group's files
-        for(const fileIndexData of indexedFiles) {
+        for (const fileIndexData of indexedFiles) {
             const file = new FlatFile(fileIndexData, {
-                group: this, archive: this.archive, store: this.store
+                group: this,
+                archive: this.archive,
+                store: this.store,
             });
 
             this.files.set(file.key, file);
@@ -251,10 +305,12 @@ export class Group extends IndexedFile<GroupIndexEntity> {
         this.stripeCount = (this.index as GroupIndexEntity).stripeCount || 1;
 
         // Read the content of each file within the group
-        if(readDiskFiles) {
-            Array.from(this.files.values()).forEach(file => file.read(compress));
+        if (readDiskFiles) {
+            Array.from(this.files.values()).forEach((file) =>
+                file.read(compress),
+            );
 
-            if(this._fileCount === 1) {
+            if (this._fileCount === 1) {
                 // Single file group, set the group data to match the flat file data
                 const file = this.files.get('0');
                 this.setData(file.data, file.state);
@@ -266,13 +322,13 @@ export class Group extends IndexedFile<GroupIndexEntity> {
         const originalDigest = this.sha256;
         this.generateSha256();
 
-        if(this.sha256 && originalDigest !== this.sha256) {
+        if (this.sha256 && originalDigest !== this.sha256) {
             // logger.info(`Detected changes in file ${this.archive.name}:${groupName}.`);
             this.index.sha256 = this.sha256;
             this._modified = true;
         }
 
-        if(compress && this.state !== FileState.compressed) {
+        if (compress && this.state !== FileState.compressed) {
             this.compress();
         }
 
@@ -280,7 +336,7 @@ export class Group extends IndexedFile<GroupIndexEntity> {
     }
 
     public override write(): void {
-        if(!this._fileCount) {
+        if (!this._fileCount) {
             logger.error(`Error writing group ${this.name}: Group is empty.`);
             return;
         }
@@ -289,16 +345,16 @@ export class Group extends IndexedFile<GroupIndexEntity> {
 
         const groupPath = this.outputPath;
 
-        if(existsSync(groupPath)) {
+        if (existsSync(groupPath)) {
             rmSync(groupPath, { recursive: true, force: true });
         }
 
-        if(this.files.size > 1 && !this.archive.config.flatten) {
+        if (this.files.size > 1 && !this.archive.config.flatten) {
             mkdirSync(groupPath, { recursive: true });
         }
 
-        if(!this.archive.config.flatten) {
-            Array.from(this.files.values()).forEach(file => file.write());
+        if (!this.archive.config.flatten) {
+            Array.from(this.files.values()).forEach((file) => file.write());
         } else {
             super.write();
         }
@@ -319,8 +375,10 @@ export class Group extends IndexedFile<GroupIndexEntity> {
 
     public override get path(): string {
         const archivePath = this.archive?.path || null;
-        if(!archivePath) {
-            throw new Error(`Error generating group path; Archive path not provided to group ${this.key}.`);
+        if (!archivePath) {
+            throw new Error(
+                `Error generating group path; Archive path not provided to group ${this.key}.`,
+            );
         }
 
         return join(archivePath, String(this.name || this.key));
@@ -328,11 +386,16 @@ export class Group extends IndexedFile<GroupIndexEntity> {
 
     public override get outputPath(): string {
         const archiveOutputPath = this.archive?.outputPath || null;
-        if(!archiveOutputPath) {
-            throw new Error(`Error generating group output path; Archive output path not provided to group ${this.key}.`);
+        if (!archiveOutputPath) {
+            throw new Error(
+                `Error generating group output path; Archive output path not provided to group ${this.key}.`,
+            );
         }
 
-        const groupPath = join(archiveOutputPath, String(this.name || this.key));
+        const groupPath = join(
+            archiveOutputPath,
+            String(this.name || this.key),
+        );
         return this.archive.config.flatten ? groupPath + this.type : groupPath;
     }
 

--- a/src/group.ts
+++ b/src/group.ts
@@ -1,10 +1,10 @@
-import { join } from 'path';
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'graceful-fs';
+import { join } from 'node:path';
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { ByteBuffer, logger } from '@runejs/common';
 
 import { FlatFile } from './flat-file';
-import { GroupIndexEntity } from './db';
-import { FileBreadcrumb, IndexedFile } from './indexed-file';
+import type { GroupIndexEntity } from './db';
+import { type FileBreadcrumb, IndexedFile } from './indexed-file';
 import { FileState } from './file-state';
 import { isSet } from './util';
 
@@ -15,9 +15,9 @@ export class Group extends IndexedFile<GroupIndexEntity> {
     public readonly fileSizes: Map<string, number> = new Map<string, number>();
 
     public stripes: number[] = [];
-    public stripeCount: number = 1;
+    public stripeCount = 1;
 
-    private _fileCount: number = 0;
+    private _fileCount = 0;
 
     public constructor(index: GroupIndexEntity, breadcrumb?: Partial<FileBreadcrumb>) {
         super(index, breadcrumb);
@@ -154,7 +154,9 @@ export class Group extends IndexedFile<GroupIndexEntity> {
         const groupSize = fileSizes.reduce((a, c) => a + c) + (stripeCount * fileCount * 4) + 1;
         const groupBuffer = new ByteBuffer(groupSize);
 
-        fileData.forEach(data => data.readerIndex = 0);
+        fileData.forEach(data => {
+            data.readerIndex = 0;
+        });
 
         // Write file content stripes
         for(let stripe = 0; stripe < stripeCount; stripe++) {
@@ -192,7 +194,7 @@ export class Group extends IndexedFile<GroupIndexEntity> {
         return this._data;
     }
 
-    public override async read(compress: boolean = false, readDiskFiles: boolean = true): Promise<ByteBuffer | null> {
+    public override async read(compress = false, readDiskFiles = true): Promise<ByteBuffer | null> {
         if(!this.index) {
             logger.error(`Error reading group ${this.name} files: Group is not indexed, please re-index the ` +
                 `${this.archive.name} archive.`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,3 @@ export * from './file-state';
 export * from './util';
 export * from './db';
 export * from './config';
-

--- a/src/indexed-file.ts
+++ b/src/indexed-file.ts
@@ -1,14 +1,14 @@
-import { writeFileSync } from 'graceful-fs';
-import { createHash } from 'crypto';
+import { writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { ByteBuffer, logger } from '@runejs/common';
-import { Bzip2, CompressionMethod, getCompressionMethod, Gzip } from '@runejs/common/compress';
-import { EncryptionMethod, Xtea, XteaKeys } from '@runejs/common/encrypt';
+import { Bzip2, type CompressionMethod, getCompressionMethod, Gzip } from '@runejs/common/compress';
+import { type EncryptionMethod, Xtea, type XteaKeys } from '@runejs/common/encrypt';
 import { Crc32 } from '@runejs/common/crc32';
 
-import { IndexEntity, IndexService } from './db';
-import { Store } from './store';
-import { Archive } from './archive';
-import { Group } from './group';
+import type { IndexEntity, IndexService } from './db';
+import type { Store } from './store';
+import type { Archive } from './archive';
+import type { Group } from './group';
 import { isSet } from './util';
 import { FileState } from './file-state';
 
@@ -28,18 +28,18 @@ export abstract class IndexedFile<T extends IndexEntity> {
     public readonly group: Group;
 
     public index: T;
-    public name: string = '';
-    public nameHash: number = -1;
-    public version: number = 0;
-    public size: number = 0;
-    public crc32: number = -1;
-    public sha256: string = '';
+    public name = '';
+    public nameHash = -1;
+    public version = 0;
+    public size = 0;
+    public crc32 = -1;
+    public sha256 = '';
     public encryption: EncryptionMethod | [ EncryptionMethod, string ] = 'none';
     public compression: CompressionMethod = 'none';
     public state: FileState = FileState.unloaded;
 
     protected _data: ByteBuffer | null = null;
-    protected _modified: boolean = false;
+    protected _modified = false;
 
     protected constructor(index: T, breadcrumb?: Partial<FileBreadcrumb>) {
         this.index = index;
@@ -57,8 +57,8 @@ export abstract class IndexedFile<T extends IndexEntity> {
         if(isSet(index.sha256)) {
             this.sha256 = index.sha256;
         }
-        if(isSet(index['state'])) {
-            this.state = FileState[index['state']];
+        if(isSet(index.state)) {
+            this.state = FileState[index.state];
         }
 
         if(breadcrumb) {
@@ -233,7 +233,7 @@ export abstract class IndexedFile<T extends IndexEntity> {
             // BZIP or GZIP compressed file
             const decompressedLength = compressedData.get('int', 'unsigned');
             if(decompressedLength < 0) {
-                logger.error(this.encryption === 'xtea' ? `Missing or invalid XTEA key.` :
+                logger.error(this.encryption === 'xtea' ? 'Missing or invalid XTEA key.' :
                     `Invalid decompressed file length: ${decompressedLength}`);
             } else {
                 const decompressedData = new ByteBuffer(this.compression === 'bzip' ?
@@ -247,7 +247,7 @@ export abstract class IndexedFile<T extends IndexEntity> {
                     compressedData.readerIndex = compressedData.readerIndex + compressedLength;
 
                     if(data.length !== decompressedLength) {
-                        logger.error(`Compression length mismatch.`);
+                        logger.error('Compression length mismatch.');
                         data = null;
                     }
                 } catch(error) {
@@ -351,8 +351,8 @@ export abstract class IndexedFile<T extends IndexEntity> {
         if(!gameBuild) {
             if(this.store && !this.store.gameBuildMissing) {
                 this.store.setGameBuildMissing();
-                logger.warn(`Game build must be supplied to decompress XTEA encrypted files.`,
-                    `Please provide the game build using the --build argument.`);
+                logger.warn('Game build must be supplied to decompress XTEA encrypted files.',
+                    'Please provide the game build using the --build argument.');
             }
 
             this.setState(FileState.decrypted);
@@ -395,9 +395,8 @@ export abstract class IndexedFile<T extends IndexEntity> {
                 dataCopy.readerIndex = readerIndex;
                 this.setState(FileState.decrypted);
                 return dataCopy;
-            } else {
-                logger.warn(`Invalid XTEA decryption keys found for file ${this.name || this.key} using game build ${gameBuild}.`);
             }
+                logger.warn(`Invalid XTEA decryption keys found for file ${this.name || this.key} using game build ${gameBuild}.`);
         } else {
             // logger.warn(`No XTEA decryption keys found for file ${this.name || this.fileKey} using game build ${gameBuild}.`);
         }
@@ -476,7 +475,7 @@ export abstract class IndexedFile<T extends IndexEntity> {
     }
 
     public get hasNameHash(): boolean {
-        return isSet(this.nameHash) && !isNaN(this.nameHash) && this.nameHash !== -1;
+        return isSet(this.nameHash) && !Number.isNaN(this.nameHash) && this.nameHash !== -1;
     }
 
     public get data(): ByteBuffer {

--- a/src/indexed-file.ts
+++ b/src/indexed-file.ts
@@ -1,8 +1,17 @@
 import { writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { ByteBuffer, logger } from '@runejs/common';
-import { Bzip2, type CompressionMethod, getCompressionMethod, Gzip } from '@runejs/common/compress';
-import { type EncryptionMethod, Xtea, type XteaKeys } from '@runejs/common/encrypt';
+import {
+    Bzip2,
+    type CompressionMethod,
+    getCompressionMethod,
+    Gzip,
+} from '@runejs/common/compress';
+import {
+    type EncryptionMethod,
+    Xtea,
+    type XteaKeys,
+} from '@runejs/common/encrypt';
 import { Crc32 } from '@runejs/common/crc32';
 
 import type { IndexEntity, IndexService } from './db';
@@ -12,16 +21,13 @@ import type { Group } from './group';
 import { isSet } from './util';
 import { FileState } from './file-state';
 
-
 export interface FileBreadcrumb {
     store: Store;
     archive: Archive;
     group: Group;
 }
 
-
 export abstract class IndexedFile<T extends IndexEntity> {
-
     public readonly key: string;
     public readonly store: Store;
     public readonly archive: Archive;
@@ -34,7 +40,7 @@ export abstract class IndexedFile<T extends IndexEntity> {
     public size = 0;
     public crc32 = -1;
     public sha256 = '';
-    public encryption: EncryptionMethod | [ EncryptionMethod, string ] = 'none';
+    public encryption: EncryptionMethod | [EncryptionMethod, string] = 'none';
     public compression: CompressionMethod = 'none';
     public state: FileState = FileState.unloaded;
 
@@ -45,48 +51,48 @@ export abstract class IndexedFile<T extends IndexEntity> {
         this.index = index;
         this.key = String(index.key);
 
-        if(isSet(index.name)) {
+        if (isSet(index.name)) {
             this.name = index.name;
         }
-        if(isSet(index.size)) {
+        if (isSet(index.size)) {
             this.size = index.size;
         }
-        if(isSet(index.crc32)) {
+        if (isSet(index.crc32)) {
             this.crc32 = index.crc32;
         }
-        if(isSet(index.sha256)) {
+        if (isSet(index.sha256)) {
             this.sha256 = index.sha256;
         }
-        if(isSet(index.state)) {
+        if (isSet(index.state)) {
             this.state = FileState[index.state];
         }
 
-        if(breadcrumb) {
+        if (breadcrumb) {
             const { store, archive, group } = breadcrumb;
-            
-            if(isSet(store)) {
+
+            if (isSet(store)) {
                 this.store = store;
             }
-            if(isSet(archive)) {
+            if (isSet(archive)) {
                 this.archive = archive;
             }
-            if(isSet(group)) {
+            if (isSet(group)) {
                 this.group = group;
             }
         }
 
         // Attempt to infer the archive or store that this file belongs to, if not provided in the options
 
-        if(!this.archive) {
-            if(this.group?.archive) {
+        if (!this.archive) {
+            if (this.group?.archive) {
                 this.archive = this.group.archive;
             }
         }
 
-        if(!this.store) {
-            if(this.archive?.store) {
+        if (!this.store) {
+            if (this.archive?.store) {
                 this.store = this.archive.store;
-            } else if(this.group?.store) {
+            } else if (this.group?.store) {
                 this.store = this.group.store;
             }
         }
@@ -99,10 +105,12 @@ export abstract class IndexedFile<T extends IndexEntity> {
         const archiveKey: number = this.archive ? this.archive.numericKey : 255;
         const fileKey = this.numericKey;
         const archiveName: string = this.archive ? this.archive.name : 'main';
-        const indexChannel: ByteBuffer = archiveKey !== 255 ?
-            this.store.js5ArchiveIndexes.get(String(archiveKey)) : this.store.js5MainIndex;
+        const indexChannel: ByteBuffer =
+            archiveKey !== 255
+                ? this.store.js5ArchiveIndexes.get(String(archiveKey))
+                : this.store.js5MainIndex;
 
-        if(archiveKey === 255 && fileKey === 255) {
+        if (archiveKey === 255 && fileKey === 255) {
             return null;
         }
 
@@ -114,24 +122,30 @@ export abstract class IndexedFile<T extends IndexEntity> {
 
         let pointer = fileKey * indexDataLength;
 
-        if(pointer < 0 || pointer >= indexChannel.length) {
-            logger.error(`File ${fileKey} was not found within the ${archiveName} archive index file.`);
+        if (pointer < 0 || pointer >= indexChannel.length) {
+            logger.error(
+                `File ${fileKey} was not found within the ${archiveName} archive index file.`,
+            );
             return null;
         }
 
         const fileIndexData = new ByteBuffer(indexDataLength);
         indexChannel.copy(fileIndexData, 0, pointer, pointer + indexDataLength);
 
-        if(fileIndexData.readable !== indexDataLength) {
-            logger.error(`Error extracting JS5 file ${fileKey}: the end of the data stream was reached.`);
+        if (fileIndexData.readable !== indexDataLength) {
+            logger.error(
+                `Error extracting JS5 file ${fileKey}: the end of the data stream was reached.`,
+            );
             return null;
         }
 
         this.size = fileIndexData.get('int24', 'unsigned');
         const stripeCount = fileIndexData.get('int24', 'unsigned');
 
-        if(this.size <= 0) {
-            logger.warn(`Extracted JS5 file ${fileKey} has a recorded size of 0, no file data will be extracted.`);
+        if (this.size <= 0) {
+            logger.warn(
+                `Extracted JS5 file ${fileKey} has a recorded size of 0, no file data will be extracted.`,
+            );
             return null;
         }
 
@@ -147,8 +161,10 @@ export abstract class IndexedFile<T extends IndexEntity> {
             const temp = new ByteBuffer(stripeLength);
             dataChannel.copy(temp, 0, pointer, pointer + stripeLength);
 
-            if(temp.readable !== stripeLength) {
-                logger.error(`Error reading stripe for packed file ${fileKey}, the end of the data stream was reached.`);
+            if (temp.readable !== stripeLength) {
+                logger.error(
+                    `Error reading stripe for packed file ${fileKey}, the end of the data stream was reached.`,
+                );
                 return null;
             }
 
@@ -157,37 +173,48 @@ export abstract class IndexedFile<T extends IndexEntity> {
             const nextStripe = temp.get('int24', 'unsigned');
             const stripeArchiveIndex = temp.get('byte', 'unsigned');
             const stripeData = new ByteBuffer(stripeDataLength);
-            temp.copy(stripeData, 0, temp.readerIndex, temp.readerIndex + stripeDataLength);
+            temp.copy(
+                stripeData,
+                0,
+                temp.readerIndex,
+                temp.readerIndex + stripeDataLength,
+            );
 
-            if(remaining > stripeDataLength) {
+            if (remaining > stripeDataLength) {
                 stripeData.copy(data, data.writerIndex, 0, stripeDataLength);
-                data.writerIndex = (data.writerIndex + stripeDataLength);
+                data.writerIndex = data.writerIndex + stripeDataLength;
                 remaining -= stripeDataLength;
 
-                if(stripeArchiveIndex !== archiveKey) {
-                    logger.error(`Archive index mismatch, expected archive ${archiveKey} but found archive ${stripeFileIndex}`);
+                if (stripeArchiveIndex !== archiveKey) {
+                    logger.error(
+                        `Archive index mismatch, expected archive ${archiveKey} but found archive ${stripeFileIndex}`,
+                    );
                     return null;
                 }
 
-                if(stripeFileIndex !== fileKey) {
-                    logger.error(`File index mismatch, expected ${fileKey} but found ${stripeFileIndex}.`);
+                if (stripeFileIndex !== fileKey) {
+                    logger.error(
+                        `File index mismatch, expected ${fileKey} but found ${stripeFileIndex}.`,
+                    );
                     return null;
                 }
 
-                if(currentStripe !== stripe++) {
-                    logger.error(`Error extracting JS5 file ${fileKey}, file data is corrupted.`);
+                if (currentStripe !== stripe++) {
+                    logger.error(
+                        `Error extracting JS5 file ${fileKey}, file data is corrupted.`,
+                    );
                     return null;
                 }
 
                 pointer = nextStripe * stripeLength;
             } else {
                 stripeData.copy(data, data.writerIndex, 0, remaining);
-                data.writerIndex = (data.writerIndex + remaining);
+                data.writerIndex = data.writerIndex + remaining;
                 remaining = 0;
             }
-        } while(remaining > 0);
+        } while (remaining > 0);
 
-        if(data?.length) {
+        if (data?.length) {
             this.setData(data, FileState.compressed);
         } else {
             this.setData(null, FileState.missing);
@@ -209,13 +236,15 @@ export abstract class IndexedFile<T extends IndexEntity> {
     }
 
     public decompress(): ByteBuffer | null {
-        if(!this._data?.length) {
+        if (!this._data?.length) {
             return null;
         }
 
         this._data.readerIndex = 0;
 
-        this.compression = getCompressionMethod(this._data.get('byte', 'unsigned'));
+        this.compression = getCompressionMethod(
+            this._data.get('byte', 'unsigned'),
+        );
         const compressedLength = this._data.get('int', 'unsigned');
 
         const readerIndex = this._data.readerIndex;
@@ -224,38 +253,64 @@ export abstract class IndexedFile<T extends IndexEntity> {
         compressedData.readerIndex = readerIndex;
         let data: ByteBuffer;
 
-        if(this.compression === 'none') {
+        if (this.compression === 'none') {
             // Uncompressed file
             data = new ByteBuffer(compressedLength);
-            compressedData.copy(data, 0, compressedData.readerIndex, compressedLength);
-            compressedData.readerIndex = (compressedData.readerIndex + compressedLength);
+            compressedData.copy(
+                data,
+                0,
+                compressedData.readerIndex,
+                compressedLength,
+            );
+            compressedData.readerIndex =
+                compressedData.readerIndex + compressedLength;
         } else {
             // BZIP or GZIP compressed file
             const decompressedLength = compressedData.get('int', 'unsigned');
-            if(decompressedLength < 0) {
-                logger.error(this.encryption === 'xtea' ? 'Missing or invalid XTEA key.' :
-                    `Invalid decompressed file length: ${decompressedLength}`);
+            if (decompressedLength < 0) {
+                logger.error(
+                    this.encryption === 'xtea'
+                        ? 'Missing or invalid XTEA key.'
+                        : `Invalid decompressed file length: ${decompressedLength}`,
+                );
             } else {
-                const decompressedData = new ByteBuffer(this.compression === 'bzip' ?
-                    decompressedLength : (compressedData.length - compressedData.readerIndex + 2));
+                const decompressedData = new ByteBuffer(
+                    this.compression === 'bzip'
+                        ? decompressedLength
+                        : compressedData.length -
+                              compressedData.readerIndex +
+                              2,
+                );
 
-                compressedData.copy(decompressedData, 0, compressedData.readerIndex);
+                compressedData.copy(
+                    decompressedData,
+                    0,
+                    compressedData.readerIndex,
+                );
 
                 try {
-                    data = this.compression === 'bzip' ? Bzip2.decompress(decompressedData) : Gzip.decompress(decompressedData);
+                    data =
+                        this.compression === 'bzip'
+                            ? Bzip2.decompress(decompressedData)
+                            : Gzip.decompress(decompressedData);
 
-                    compressedData.readerIndex = compressedData.readerIndex + compressedLength;
+                    compressedData.readerIndex =
+                        compressedData.readerIndex + compressedLength;
 
-                    if(data.length !== decompressedLength) {
+                    if (data.length !== decompressedLength) {
                         logger.error('Compression length mismatch.');
                         data = null;
                     }
-                } catch(error) {
-                    if(this.state === FileState.encrypted) {
-                        logger.error(`Unable to decrypt file ${this.name || this.key}.`);
+                } catch (error) {
+                    if (this.state === FileState.encrypted) {
+                        logger.error(
+                            `Unable to decrypt file ${this.name || this.key}.`,
+                        );
                         this.archive?.incrementMissingEncryptionKeys();
                     } else {
-                        logger.error(`Unable to decompress file ${this.name || this.key}: ${error?.message ?? error}`);
+                        logger.error(
+                            `Unable to decompress file ${this.name || this.key}: ${error?.message ?? error}`,
+                        );
                     }
                     data = null;
                 }
@@ -263,11 +318,11 @@ export abstract class IndexedFile<T extends IndexEntity> {
         }
 
         // Read the file footer, if it has one
-        if(compressedData.readable >= 2) {
+        if (compressedData.readable >= 2) {
             this.version = compressedData.get('short', 'unsigned');
         }
 
-        if((data?.length ?? 0) > 0) {
+        if ((data?.length ?? 0) > 0) {
             this.setData(data, FileState.encoded);
         }
 
@@ -275,14 +330,14 @@ export abstract class IndexedFile<T extends IndexEntity> {
     }
 
     public compress(): ByteBuffer | null {
-        if(!this._data?.length) {
+        if (!this._data?.length) {
             return null;
         }
 
         const decompressedData = this._data;
         let data: ByteBuffer;
 
-        if(this.compression === 'none') {
+        if (this.compression === 'none') {
             // uncompressed files
             data = new ByteBuffer(decompressedData.length + 5);
 
@@ -297,8 +352,10 @@ export abstract class IndexedFile<T extends IndexEntity> {
         } else {
             // compressed Bzip2 or Gzip file
 
-            const compressedData: ByteBuffer = this.compression === 'bzip' ?
-                Bzip2.compress(decompressedData) : Gzip.compress(decompressedData);
+            const compressedData: ByteBuffer =
+                this.compression === 'bzip'
+                    ? Bzip2.compress(decompressedData)
+                    : Gzip.compress(decompressedData);
 
             const compressedLength: number = compressedData.length;
 
@@ -321,24 +378,26 @@ export abstract class IndexedFile<T extends IndexEntity> {
     }
 
     public decrypt(): ByteBuffer {
-        if(this.state === FileState.encrypted) {
-        // if(this.archive?.config?.encryption) {
+        if (this.state === FileState.encrypted) {
+            // if(this.archive?.config?.encryption) {
             // File name must match the given pattern to be encrypted
-            if(!this.name) {
-                throw new Error(`Error decrypting file ${this.key}: File name not found.`);
+            if (!this.name) {
+                throw new Error(
+                    `Error decrypting file ${this.key}: File name not found.`,
+                );
             }
 
-            if(Array.isArray(this.archive.config.encryption)) {
-                const [ encryption, pattern ] = this.archive.config.encryption;
+            if (Array.isArray(this.archive.config.encryption)) {
+                const [encryption, pattern] = this.archive.config.encryption;
                 const patternRegex = new RegExp(pattern);
 
                 // Only XTEA encryption is supported for v1.0.0
-                if(encryption !== 'xtea' || !patternRegex.test(this.name)) {
+                if (encryption !== 'xtea' || !patternRegex.test(this.name)) {
                     // File name does not match the pattern, data should be unencrypted
                     this.setState(FileState.decrypted);
                     return this._data;
                 }
-            } else if(this.archive.config.encryption !== 'xtea') {
+            } else if (this.archive.config.encryption !== 'xtea') {
                 // Only XTEA encryption is supported for v1.0.0
                 this.setState(FileState.decrypted);
                 return this._data;
@@ -348,11 +407,13 @@ export abstract class IndexedFile<T extends IndexEntity> {
         const gameBuild = this.store.gameBuild ?? null;
 
         // XTEA requires that we know which game build is running so that we pick the correct keystore file
-        if(!gameBuild) {
-            if(this.store && !this.store.gameBuildMissing) {
+        if (!gameBuild) {
+            if (this.store && !this.store.gameBuildMissing) {
                 this.store.setGameBuildMissing();
-                logger.warn('Game build must be supplied to decompress XTEA encrypted files.',
-                    'Please provide the game build using the --build argument.');
+                logger.warn(
+                    'Game build must be supplied to decompress XTEA encrypted files.',
+                    'Please provide the game build using the --build argument.',
+                );
             }
 
             this.setState(FileState.decrypted);
@@ -362,9 +423,9 @@ export abstract class IndexedFile<T extends IndexEntity> {
         let keySets: XteaKeys[] = [];
 
         const loadedKeys = this.store.getEncryptionKeys(this.name);
-        if(loadedKeys) {
-            if(!Array.isArray(loadedKeys)) {
-                keySets = [ loadedKeys ];
+        if (loadedKeys) {
+            if (!Array.isArray(loadedKeys)) {
+                keySets = [loadedKeys];
             } else {
                 keySets = loadedKeys;
             }
@@ -372,31 +433,39 @@ export abstract class IndexedFile<T extends IndexEntity> {
 
         this._data.readerIndex = 0;
 
-        this.compression = getCompressionMethod(this._data.get('byte', 'unsigned'));
+        this.compression = getCompressionMethod(
+            this._data.get('byte', 'unsigned'),
+        );
         const compressedLength = this._data.get('int', 'unsigned');
 
         const readerIndex = this._data.readerIndex;
 
-        const keySet = keySets.find(keySet => keySet.gameBuild === gameBuild);
+        const keySet = keySets.find((keySet) => keySet.gameBuild === gameBuild);
 
-        if(Xtea.validKeys(keySet?.key)) {
+        if (Xtea.validKeys(keySet?.key)) {
             const dataCopy = this._data.clone();
             dataCopy.readerIndex = readerIndex;
 
             let lengthOffset = readerIndex;
-            if(dataCopy.length - (compressedLength + readerIndex + 4) >= 2) {
+            if (dataCopy.length - (compressedLength + readerIndex + 4) >= 2) {
                 lengthOffset += 2;
             }
 
-            const decryptedData = Xtea.decrypt(dataCopy, keySet.key, dataCopy.length - lengthOffset);
+            const decryptedData = Xtea.decrypt(
+                dataCopy,
+                keySet.key,
+                dataCopy.length - lengthOffset,
+            );
 
-            if(decryptedData?.length) {
+            if (decryptedData?.length) {
                 decryptedData.copy(dataCopy, readerIndex, 0);
                 dataCopy.readerIndex = readerIndex;
                 this.setState(FileState.decrypted);
                 return dataCopy;
             }
-                logger.warn(`Invalid XTEA decryption keys found for file ${this.name || this.key} using game build ${gameBuild}.`);
+            logger.warn(
+                `Invalid XTEA decryption keys found for file ${this.name || this.key} using game build ${gameBuild}.`,
+            );
         } else {
             // logger.warn(`No XTEA decryption keys found for file ${this.name || this.fileKey} using game build ${gameBuild}.`);
         }
@@ -404,8 +473,10 @@ export abstract class IndexedFile<T extends IndexEntity> {
         return this._data;
     }
 
-    public read(compress?: boolean): ByteBuffer | null | Promise<ByteBuffer | null> {
-        if(this.state === FileState.unloaded) {
+    public read(
+        compress?: boolean,
+    ): ByteBuffer | null | Promise<ByteBuffer | null> {
+        if (this.state === FileState.unloaded) {
             this.setState(FileState.loaded);
         }
 
@@ -413,18 +484,24 @@ export abstract class IndexedFile<T extends IndexEntity> {
     }
 
     public write(): void {
-        if(this._data?.length) {
+        if (this._data?.length) {
             writeFileSync(this.outputPath, Buffer.from(this._data));
         }
     }
 
     public setData(data: Buffer, state: FileState): ByteBuffer | null;
     public setData(data: ByteBuffer, state: FileState): ByteBuffer | null;
-    public setData(data: ByteBuffer | Buffer, state: FileState): ByteBuffer | null;
-    public setData(data: ByteBuffer | Buffer, state: FileState): ByteBuffer | null {
+    public setData(
+        data: ByteBuffer | Buffer,
+        state: FileState,
+    ): ByteBuffer | null;
+    public setData(
+        data: ByteBuffer | Buffer,
+        state: FileState,
+    ): ByteBuffer | null {
         this.size = data?.length ?? 0;
 
-        if(this.size) {
+        if (this.size) {
             this._data = new ByteBuffer(data);
             this._data.readerIndex = 0;
             this._data.writerIndex = 0;
@@ -434,9 +511,9 @@ export abstract class IndexedFile<T extends IndexEntity> {
 
         this.state = state;
 
-        if(state === FileState.compressed) {
+        if (state === FileState.compressed) {
             this.generateCrc32();
-        } else if(state === FileState.raw || state === FileState.encoded) {
+        } else if (state === FileState.raw || state === FileState.encoded) {
             this.generateSha256();
         }
 
@@ -444,13 +521,16 @@ export abstract class IndexedFile<T extends IndexEntity> {
     }
 
     public generateCrc32(): number {
-        this.crc32 = this._data?.length ? Crc32.update(0, this.size, Buffer.from(this._data)) : -1;
+        this.crc32 = this._data?.length
+            ? Crc32.update(0, this.size, Buffer.from(this._data))
+            : -1;
         return this.crc32;
     }
 
     public generateSha256(): string {
-        this.sha256 = this._data?.length ? createHash('sha256')
-            .update(Buffer.from(this._data)).digest('hex') : '';
+        this.sha256 = this._data?.length
+            ? createHash('sha256').update(Buffer.from(this._data)).digest('hex')
+            : '';
         return this.sha256;
     }
 
@@ -467,7 +547,7 @@ export abstract class IndexedFile<T extends IndexEntity> {
     }
 
     public get named(): boolean {
-        if(!this.name) {
+        if (!this.name) {
             return false;
         }
 
@@ -475,7 +555,11 @@ export abstract class IndexedFile<T extends IndexEntity> {
     }
 
     public get hasNameHash(): boolean {
-        return isSet(this.nameHash) && !Number.isNaN(this.nameHash) && this.nameHash !== -1;
+        return (
+            isSet(this.nameHash) &&
+            !Number.isNaN(this.nameHash) &&
+            this.nameHash !== -1
+        );
     }
 
     public get data(): ByteBuffer {
@@ -495,7 +579,10 @@ export abstract class IndexedFile<T extends IndexEntity> {
     }
 
     public get modified(): boolean {
-        return this.index.crc32 !== this.crc32 || this.index.sha256 !== this.sha256 || this.index.size !== this.size;
+        return (
+            this.index.crc32 !== this.crc32 ||
+            this.index.sha256 !== this.sha256 ||
+            this.index.size !== this.size
+        );
     }
-
 }

--- a/src/scripts/indexer.ts
+++ b/src/scripts/indexer.ts
@@ -5,7 +5,6 @@ import { logger } from '@runejs/common';
 import { Store, type StoreFormat } from '../index';
 import { ScriptExecutor, type ArgumentOptions } from './index';
 
-
 interface IndexerOptions {
     dir: string;
     format: StoreFormat | 'flat' | 'js5';
@@ -13,55 +12,66 @@ interface IndexerOptions {
     build: string;
 }
 
-
 const indexerArgumentOptions: ArgumentOptions = {
     dir: {
-        alias: 'd', type: 'string', default: './',
-        description: 'The store root directory. Defaults to the current location.'
+        alias: 'd',
+        type: 'string',
+        default: './',
+        description:
+            'The store root directory. Defaults to the current location.',
     },
     format: {
-        alias: 'f', type: 'string', default: 'unpacked', choices: [ 'unpacked', 'packed', 'flat', 'js5' ],
-        description: `The format of the store to index, either 'unpacked' (flat files) or 'packed' (JS5 format). Defaults to 'unpacked'.`
+        alias: 'f',
+        type: 'string',
+        default: 'unpacked',
+        choices: ['unpacked', 'packed', 'flat', 'js5'],
+        description: `The format of the store to index, either 'unpacked' (flat files) or 'packed' (JS5 format). Defaults to 'unpacked'.`,
     },
     archive: {
-        alias: 'a', type: 'string', default: 'main',
-        description: `The archive to index. Defaults to 'main', which will index all store archives one by one. Specify an archive name to index a single archive.`
+        alias: 'a',
+        type: 'string',
+        default: 'main',
+        description: `The archive to index. Defaults to 'main', which will index all store archives one by one. Specify an archive name to index a single archive.`,
     },
     build: {
-        alias: 'b', type: 'string', default: '435',
-        description: `The game build (revision) that the store should belong to, also known as the game build number. Defaults to '435', a game build from late October, 2006.`
-    }
+        alias: 'b',
+        type: 'string',
+        default: '435',
+        description: `The game build (revision) that the store should belong to, also known as the game build number. Defaults to '435', a game build from late October, 2006.`,
+    },
 };
 
-
 async function indexFiles(store: Store, args: IndexerOptions): Promise<void> {
-    const argDebugString = args ? Array.from(Object.entries(args))
-        .map(([ key, val ]) => `${key} = ${val}`).join(', ') : '';
+    const argDebugString = args
+        ? Array.from(Object.entries(args))
+              .map(([key, val]) => `${key} = ${val}`)
+              .join(', ')
+        : '';
 
     const { archive: archiveName } = args;
 
     let format = args.format;
-    if(format === 'js5') {
+    if (format === 'js5') {
         format = 'packed';
-    } else if(format === 'flat') {
+    } else if (format === 'flat') {
         format = 'unpacked';
     }
 
-    if(format === 'packed') {
+    if (format === 'packed') {
         store.loadPackedStore();
     } else {
         const outputDir = store.outputPath;
-        if(!existsSync(outputDir)) {
+        if (!existsSync(outputDir)) {
             mkdirSync(outputDir, { recursive: true });
         }
     }
 
-    if(archiveName === 'main') {
+    if (archiveName === 'main') {
         logger.info(`Indexing ${format} store with arguments:`, argDebugString);
 
-        if(format === 'unpacked') {
+        if (format === 'unpacked') {
             await store.read();
-        } else if(format === 'packed') {
+        } else if (format === 'packed') {
             store.decode(true);
         }
 
@@ -70,13 +80,16 @@ async function indexFiles(store: Store, args: IndexerOptions): Promise<void> {
 
         await store.saveIndexData(true, true, true);
     } else {
-        logger.info(`Indexing ${format} archive ${archiveName} with arguments:`, argDebugString);
+        logger.info(
+            `Indexing ${format} archive ${archiveName} with arguments:`,
+            argDebugString,
+        );
 
         const archive = store.find(archiveName);
 
-        if(format === 'unpacked') {
+        if (format === 'unpacked') {
             await archive.read(false);
-        } else if(format === 'packed') {
+        } else if (format === 'packed') {
             archive.decode();
         }
 
@@ -88,30 +101,32 @@ async function indexFiles(store: Store, args: IndexerOptions): Promise<void> {
     }
 }
 
+new ScriptExecutor().executeScript<IndexerOptions>(
+    indexerArgumentOptions,
+    async (terminal, args) => {
+        const start = Date.now();
+        logger.info('Indexing store...');
 
-new ScriptExecutor().executeScript<IndexerOptions>(indexerArgumentOptions, async (terminal, args) => {
-    const start = Date.now();
-    logger.info('Indexing store...');
+        const { build, dir } = args;
 
-    const { build, dir } = args;
+        const logDir = join(dir, 'logs');
 
-    const logDir = join(dir, 'logs');
+        if (!existsSync(logDir)) {
+            mkdirSync(logDir, { recursive: true });
+        }
 
-    if(!existsSync(logDir)) {
-        mkdirSync(logDir, { recursive: true });
-    }
+        logger.destination(join(logDir, `index_${build}.log`));
 
-    logger.destination(join(logDir, `index_${build}.log`));
+        const store = await Store.create(build, dir);
 
-    const store = await Store.create(build, dir);
+        await indexFiles(store, args);
 
-    await indexFiles(store, args);
+        logger.boom.flushSync();
+        logger.boom.end();
 
-    logger.boom.flushSync();
-    logger.boom.end();
+        const end = Date.now();
+        logger.info(`Indexing completed in ${(end - start) / 1000} seconds.`);
 
-    const end = Date.now();
-    logger.info(`Indexing completed in ${(end - start) / 1000} seconds.`);
-
-    process.exit(0);
-});
+        process.exit(0);
+    },
+);

--- a/src/scripts/indexer.ts
+++ b/src/scripts/indexer.ts
@@ -1,9 +1,9 @@
-import { join } from 'path';
-import { existsSync, mkdirSync } from 'graceful-fs';
+import { join } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
 import { logger } from '@runejs/common';
 
-import { Store, StoreFormat } from '../index';
-import { ScriptExecutor, ArgumentOptions } from './index';
+import { Store, type StoreFormat } from '../index';
+import { ScriptExecutor, type ArgumentOptions } from './index';
 
 
 interface IndexerOptions {
@@ -17,7 +17,7 @@ interface IndexerOptions {
 const indexerArgumentOptions: ArgumentOptions = {
     dir: {
         alias: 'd', type: 'string', default: './',
-        description: `The store root directory. Defaults to the current location.`
+        description: 'The store root directory. Defaults to the current location.'
     },
     format: {
         alias: 'f', type: 'string', default: 'unpacked', choices: [ 'unpacked', 'packed', 'flat', 'js5' ],
@@ -91,7 +91,7 @@ async function indexFiles(store: Store, args: IndexerOptions): Promise<void> {
 
 new ScriptExecutor().executeScript<IndexerOptions>(indexerArgumentOptions, async (terminal, args) => {
     const start = Date.now();
-    logger.info(`Indexing store...`);
+    logger.info('Indexing store...');
 
     const { build, dir } = args;
 

--- a/src/scripts/script-executor.ts
+++ b/src/scripts/script-executor.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs/yargs';
-import { Options } from 'yargs';
+import type { Options } from 'yargs';
 
 
 export type ArgumentOptions = { [key: string]: Options };
@@ -8,14 +8,14 @@ export type ArgumentOptions = { [key: string]: Options };
 export class ScriptExecutor {
 
     public getArguments<T>(argumentOptions: ArgumentOptions): T {
-        return yargs(process.argv.slice(2)).options(argumentOptions).argv as any as T;
+        return yargs(process.argv.slice(2)).options(argumentOptions).argv as unknown as T;
     }
 
     public executeScript<T>(argumentOptions: ArgumentOptions,
                          executor: (terminalInterface: ScriptExecutor, args: T) => Promise<void>): void {
-        (async function(terminal: ScriptExecutor, args: T) {
+        ((async (terminal: ScriptExecutor, args: T) => {
             await executor(terminal, args);
-        }(this, this.getArguments<T>(argumentOptions)));
+        })(this, this.getArguments<T>(argumentOptions)));
     }
 
 }

--- a/src/scripts/script-executor.ts
+++ b/src/scripts/script-executor.ts
@@ -1,21 +1,20 @@
 import yargs from 'yargs/yargs';
 import type { Options } from 'yargs';
 
-
 export type ArgumentOptions = { [key: string]: Options };
 
-
 export class ScriptExecutor {
-
     public getArguments<T>(argumentOptions: ArgumentOptions): T {
-        return yargs(process.argv.slice(2)).options(argumentOptions).argv as unknown as T;
+        return yargs(process.argv.slice(2)).options(argumentOptions)
+            .argv as unknown as T;
     }
 
-    public executeScript<T>(argumentOptions: ArgumentOptions,
-                         executor: (terminalInterface: ScriptExecutor, args: T) => Promise<void>): void {
-        ((async (terminal: ScriptExecutor, args: T) => {
+    public executeScript<T>(
+        argumentOptions: ArgumentOptions,
+        executor: (terminalInterface: ScriptExecutor, args: T) => Promise<void>,
+    ): void {
+        (async (terminal: ScriptExecutor, args: T) => {
             await executor(terminal, args);
-        })(this, this.getArguments<T>(argumentOptions)));
+        })(this, this.getArguments<T>(argumentOptions));
     }
-
 }

--- a/src/scripts/unpacker.ts
+++ b/src/scripts/unpacker.ts
@@ -1,9 +1,9 @@
-import { join } from 'path';
-import { existsSync, readdirSync, statSync, mkdirSync } from 'graceful-fs';
+import { join } from 'node:path';
+import { existsSync, readdirSync, statSync, mkdirSync } from 'node:fs';
 import { logger } from '@runejs/common';
 
 import { Store } from '../index';
-import { ScriptExecutor, ArgumentOptions } from './index';
+import { ScriptExecutor, type ArgumentOptions } from './index';
 
 
 interface UnpackOptions {
@@ -17,7 +17,7 @@ interface UnpackOptions {
 const unpackerArgumentOptions: ArgumentOptions = {
     dir: {
         alias: 'd', type: 'string', default: './',
-        description: `The store root directory. Defaults to the current location.`
+        description: 'The store root directory. Defaults to the current location.'
     },
     archive: {
         alias: 'a', type: 'string', default: 'main',
@@ -43,7 +43,7 @@ async function unpackFiles(store: Store, args: UnpackOptions): Promise<void> {
     store.loadPackedStore();
 
     if(archiveName === 'main') {
-        logger.info(`Unpacking JS5 file store with arguments:`, argDebugString);
+        logger.info('Unpacking JS5 file store with arguments:', argDebugString);
 
         store.decode(true);
 
@@ -53,14 +53,14 @@ async function unpackFiles(store: Store, args: UnpackOptions): Promise<void> {
         if(!debug) {
             store.write();
         } else {
-            logger.info(`Flat file store writing is disabled in debug mode.`);
+            logger.info('Flat file store writing is disabled in debug mode.');
         }
 
-        logger.info(`Decoding completed.`);
+        logger.info('Decoding completed.');
 
         await store.saveIndexData(true, true, true);
     } else {
-        logger.info(`Unpacking JS5 archive with arguments:`, argDebugString);
+        logger.info('Unpacking JS5 archive with arguments:', argDebugString);
 
         const a = store.find(archiveName);
 
@@ -76,10 +76,10 @@ async function unpackFiles(store: Store, args: UnpackOptions): Promise<void> {
         if(!debug) {
             a.write();
         } else {
-            logger.info(`Archive writing is disabled in debug mode.`);
+            logger.info('Archive writing is disabled in debug mode.');
         }
 
-        logger.info(`Decoding completed.`);
+        logger.info('Decoding completed.');
 
         await a.saveIndexData(true, true);
     }
@@ -88,7 +88,7 @@ async function unpackFiles(store: Store, args: UnpackOptions): Promise<void> {
 
 new ScriptExecutor().executeScript<UnpackOptions>(unpackerArgumentOptions, async (terminal, args) => {
     const start = Date.now();
-    logger.info(`Unpacking JS5 store...`);
+    logger.info('Unpacking JS5 store...');
 
     const { build, dir } = args;
 

--- a/src/scripts/unpacker.ts
+++ b/src/scripts/unpacker.ts
@@ -5,7 +5,6 @@ import { logger } from '@runejs/common';
 import { Store } from '../index';
 import { ScriptExecutor, type ArgumentOptions } from './index';
 
-
 interface UnpackOptions {
     dir: string;
     debug: boolean;
@@ -13,36 +12,45 @@ interface UnpackOptions {
     build: string;
 }
 
-
 const unpackerArgumentOptions: ArgumentOptions = {
     dir: {
-        alias: 'd', type: 'string', default: './',
-        description: 'The store root directory. Defaults to the current location.'
+        alias: 'd',
+        type: 'string',
+        default: './',
+        description:
+            'The store root directory. Defaults to the current location.',
     },
     archive: {
-        alias: 'a', type: 'string', default: 'main',
-        description: `The archive to index. Defaults to 'main', which will unpack and index all store archives one by one. Specify an archive name to unpack a single archive.`
+        alias: 'a',
+        type: 'string',
+        default: 'main',
+        description: `The archive to index. Defaults to 'main', which will unpack and index all store archives one by one. Specify an archive name to unpack a single archive.`,
     },
     build: {
-        alias: 'b', type: 'string', default: '435',
-        description: `The game build (revision) that the store should belong to, also known as the game build number. Defaults to '435', a game build from late October, 2006.`
+        alias: 'b',
+        type: 'string',
+        default: '435',
+        description: `The game build (revision) that the store should belong to, also known as the game build number. Defaults to '435', a game build from late October, 2006.`,
     },
     debug: {
-        type: 'boolean', default: false,
-        description: `Debug mode flag, when set to 'true' will not output any files to the disk. Defaults to 'false'.`
-    }
+        type: 'boolean',
+        default: false,
+        description: `Debug mode flag, when set to 'true' will not output any files to the disk. Defaults to 'false'.`,
+    },
 };
 
-
 async function unpackFiles(store: Store, args: UnpackOptions): Promise<void> {
-    const argDebugString = args ? Array.from(Object.entries(args))
-        .map(([ key, val ]) => `${key} = ${val}`).join(', ') : '';
+    const argDebugString = args
+        ? Array.from(Object.entries(args))
+              .map(([key, val]) => `${key} = ${val}`)
+              .join(', ')
+        : '';
 
     const { archive: archiveName, debug } = args;
 
     store.loadPackedStore();
 
-    if(archiveName === 'main') {
+    if (archiveName === 'main') {
         logger.info('Unpacking JS5 file store with arguments:', argDebugString);
 
         store.decode(true);
@@ -50,7 +58,7 @@ async function unpackFiles(store: Store, args: UnpackOptions): Promise<void> {
         store.encode(true);
         store.compress(true);
 
-        if(!debug) {
+        if (!debug) {
             store.write();
         } else {
             logger.info('Flat file store writing is disabled in debug mode.');
@@ -64,8 +72,8 @@ async function unpackFiles(store: Store, args: UnpackOptions): Promise<void> {
 
         const a = store.find(archiveName);
 
-        if(!a) {
-            throw new Error(`Archive ${ a } was not found.`);
+        if (!a) {
+            throw new Error(`Archive ${a} was not found.`);
         }
 
         a.decode(true);
@@ -73,7 +81,7 @@ async function unpackFiles(store: Store, args: UnpackOptions): Promise<void> {
         a.encode(true);
         a.compress(true);
 
-        if(!debug) {
+        if (!debug) {
             a.write();
         } else {
             logger.info('Archive writing is disabled in debug mode.');
@@ -85,44 +93,50 @@ async function unpackFiles(store: Store, args: UnpackOptions): Promise<void> {
     }
 }
 
+new ScriptExecutor().executeScript<UnpackOptions>(
+    unpackerArgumentOptions,
+    async (terminal, args) => {
+        const start = Date.now();
+        logger.info('Unpacking JS5 store...');
 
-new ScriptExecutor().executeScript<UnpackOptions>(unpackerArgumentOptions, async (terminal, args) => {
-    const start = Date.now();
-    logger.info('Unpacking JS5 store...');
+        const { build, dir } = args;
 
-    const { build, dir } = args;
+        const logDir = join(dir, 'logs');
 
-    const logDir = join(dir, 'logs');
-
-    if(!existsSync(logDir)) {
-        mkdirSync(logDir, { recursive: true });
-    }
-
-    logger.destination(join(logDir, `unpack_${ build }.log`));
-
-    const store = await Store.create(build, dir);
-
-    const js5Dir = join(dir, 'packed');
-
-    if(!existsSync(js5Dir)) {
-        mkdirSync(js5Dir, { recursive: true });
-        logger.error(`JS5 file store not found at: ${ js5Dir }`);
-        logger.error(`Please add the desired JS5 client file store to the ${ js5Dir } directory to unpack it.`);
-    } else {
-        const stats = statSync(js5Dir);
-        if(!stats.isDirectory() || readdirSync(js5Dir).length === 0) {
-            logger.error(`JS5 file store not found at: ${ js5Dir }`);
-            logger.error(`Please add the desired JS5 client file store to the ${ js5Dir } directory to unpack it.`);
-        } else {
-            await unpackFiles(store, args);
+        if (!existsSync(logDir)) {
+            mkdirSync(logDir, { recursive: true });
         }
-    }
 
-    logger.boom.flushSync();
-    logger.boom.end();
+        logger.destination(join(logDir, `unpack_${build}.log`));
 
-    const end = Date.now();
-    logger.info(`Unpacking completed in ${(end - start) / 1000} seconds.`);
+        const store = await Store.create(build, dir);
 
-    process.exit(0);
-});
+        const js5Dir = join(dir, 'packed');
+
+        if (!existsSync(js5Dir)) {
+            mkdirSync(js5Dir, { recursive: true });
+            logger.error(`JS5 file store not found at: ${js5Dir}`);
+            logger.error(
+                `Please add the desired JS5 client file store to the ${js5Dir} directory to unpack it.`,
+            );
+        } else {
+            const stats = statSync(js5Dir);
+            if (!stats.isDirectory() || readdirSync(js5Dir).length === 0) {
+                logger.error(`JS5 file store not found at: ${js5Dir}`);
+                logger.error(
+                    `Please add the desired JS5 client file store to the ${js5Dir} directory to unpack it.`,
+                );
+            } else {
+                await unpackFiles(store, args);
+            }
+        }
+
+        logger.boom.flushSync();
+        logger.boom.end();
+
+        const end = Date.now();
+        logger.info(`Unpacking completed in ${(end - start) / 1000} seconds.`);
+
+        process.exit(0);
+    },
+);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import {
+    existsSync,
+    mkdirSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    statSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import JSON5 from 'json5';
 import { ByteBuffer, logger } from '@runejs/common';
@@ -9,18 +16,18 @@ import { Archive, FileState } from './index';
 import { ArchiveIndexEntity, IndexService, StoreIndexEntity } from './db';
 import type { ArchiveConfig } from './config';
 
-
 export type StoreFormat = 'unpacked' | 'packed';
 
 export interface StoreOptions {
     outputPath?: string | undefined;
 }
 
-
 export class Store {
-
     public readonly archives: Map<string, Archive> = new Map<string, Archive>();
-    public readonly fileNameHashes: Map<number, string> = new Map<number, string>();
+    public readonly fileNameHashes: Map<number, string> = new Map<
+        number,
+        string
+    >();
     public readonly indexService: IndexService;
 
     private _js5MainIndex: ByteBuffer;
@@ -39,7 +46,11 @@ export class Store {
     private _gameBuild: string;
     private _gameBuildMissing: boolean;
 
-    protected constructor(gameBuild: string, path: string, outputPath?: string) {
+    protected constructor(
+        gameBuild: string,
+        path: string,
+        outputPath?: string,
+    ) {
         this._gameBuild = gameBuild;
         this._path = path;
         this._outputPath = outputPath ? outputPath : join(path, 'unpacked');
@@ -48,14 +59,18 @@ export class Store {
         Crc32.init();
     }
 
-    public static async create(gameBuild: string, path = './', options?: StoreOptions): Promise<Store> {
+    public static async create(
+        gameBuild: string,
+        path = './',
+        options?: StoreOptions,
+    ): Promise<Store> {
         const store = new Store(gameBuild, path, options?.outputPath);
 
         await store.indexService.load();
 
         store._index = await store.indexService.getStoreIndex();
 
-        if(!store._index) {
+        if (!store._index) {
             store._index = new StoreIndexEntity();
             store._index.gameBuild = gameBuild;
         }
@@ -66,73 +81,88 @@ export class Store {
         store.archives.clear();
 
         const archiveConfigs = Object.entries(store.archiveConfig);
-        const mainArchiveConfig = Array.from(Object.values(store.archiveConfig)).find(a => a.index === 255);
+        const mainArchiveConfig = Array.from(
+            Object.values(store.archiveConfig),
+        ).find((a) => a.index === 255);
 
-        if(!mainArchiveConfig) {
-            throw new Error('Main archive (index 255) configuration was not found. ' +
-                'Please configure the main archive using the archives.json5 file within the store config directory.')
+        if (!mainArchiveConfig) {
+            throw new Error(
+                'Main archive (index 255) configuration was not found. ' +
+                    'Please configure the main archive using the archives.json5 file within the store config directory.',
+            );
         }
 
         const mainArchiveIndex = new ArchiveIndexEntity();
         mainArchiveIndex.key = 255;
         mainArchiveIndex.gameBuild = gameBuild;
         mainArchiveIndex.name = 'main';
-        store._mainArchive = new Archive(mainArchiveIndex, mainArchiveConfig, { store });
+        store._mainArchive = new Archive(mainArchiveIndex, mainArchiveConfig, {
+            store,
+        });
 
         let archiveIndexes = await store.indexService.getArchiveIndexes();
 
-        if(!archiveIndexes?.length) {
+        if (!archiveIndexes?.length) {
             archiveIndexes = new Array(archiveConfigs.length);
         }
 
-        for(const [ name, config ] of archiveConfigs) {
-            if(config.index === 255) {
+        for (const [name, config] of archiveConfigs) {
+            if (config.index === 255) {
                 continue;
             }
 
-            if(config.build) {
+            if (config.build) {
                 let revision: number;
-                if(gameBuild.includes('_')) {
-                    revision = Number(gameBuild.substring(gameBuild.indexOf('_') + 1));
+                if (gameBuild.includes('_')) {
+                    revision = Number(
+                        gameBuild.substring(gameBuild.indexOf('_') + 1),
+                    );
                 } else {
                     revision = Number(gameBuild);
                 }
-                if(revision < config.build) {
+                if (revision < config.build) {
                     // logger.info(`Skipping archive ${name} as it is not available in this game build.`);
                     continue;
                 }
             }
 
-            let archiveIndex = archiveIndexes.find(a => a?.key === config.index);
-            if(!archiveIndex) {
+            let archiveIndex = archiveIndexes.find(
+                (a) => a?.key === config.index,
+            );
+            if (!archiveIndex) {
                 archiveIndex = store.indexService.validateArchive({
                     numericKey: config.index,
                     name,
                     nameHash: store.hashFileName(name),
-                    config
+                    config,
                 });
             }
 
             const archive = new Archive(archiveIndex, config, {
-                store, archive: store._mainArchive
+                store,
+                archive: store._mainArchive,
             });
 
             store.archives.set(archive.key, archive);
 
             // Bulk-fetch the archive's groups
             // biome-ignore lint/suspicious/noAssignInExpressions: Legacy
-                        const groups = archiveIndex.groups = await store.indexService.getGroupIndexes(archiveIndex);
+            const groups = (archiveIndex.groups =
+                await store.indexService.getGroupIndexes(archiveIndex));
 
             // Bulk-fetch the archive's files and sort them into the appropriate groups
-            const archiveFileIndexes = await store.indexService.getFileIndexes(archiveIndex);
-            for(const fileIndex of archiveFileIndexes) {
-                const group = groups.find(group => group.key === fileIndex.groupKey);
-                if(!group) {
+            const archiveFileIndexes =
+                await store.indexService.getFileIndexes(archiveIndex);
+            for (const fileIndex of archiveFileIndexes) {
+                const group = groups.find(
+                    (group) => group.key === fileIndex.groupKey,
+                );
+                if (!group) {
                     continue;
                 }
 
-                if(!Array.isArray(group.files) || !group.files?.length) {
-                    group.files = [ fileIndex ];
+                if (!Array.isArray(group.files) || !group.files?.length) {
+                    group.files = [fileIndex];
                 } else {
                     group.files.push(fileIndex);
                 }
@@ -145,12 +175,12 @@ export class Store {
     public loadPackedStore(): void {
         const js5StorePath = join(this.path, 'packed');
 
-        if(!existsSync(js5StorePath)) {
+        if (!existsSync(js5StorePath)) {
             throw new Error(`${js5StorePath} could not be found.`);
         }
 
         const stats = statSync(js5StorePath);
-        if(!stats?.isDirectory()) {
+        if (!stats?.isDirectory()) {
             throw new Error(`${js5StorePath} is not a valid directory.`);
         }
 
@@ -158,12 +188,16 @@ export class Store {
         const dataFile = 'main_file_cache.dat2';
         const mainIndexFile = 'main_file_cache.idx255';
 
-        if(storeFileNames.indexOf(dataFile) === -1) {
-            throw new Error(`The main ${dataFile} data file could not be found.`);
+        if (storeFileNames.indexOf(dataFile) === -1) {
+            throw new Error(
+                `The main ${dataFile} data file could not be found.`,
+            );
         }
 
-        if(storeFileNames.indexOf(mainIndexFile) === -1) {
-            throw new Error(`The main ${mainIndexFile} index file could not be found.`);
+        if (storeFileNames.indexOf(mainIndexFile) === -1) {
+            throw new Error(
+                `The main ${mainIndexFile} index file could not be found.`,
+            );
         }
 
         const indexFilePrefix = 'main_file_cache.idx';
@@ -174,29 +208,40 @@ export class Store {
         this._js5MainIndex = new ByteBuffer(readFileSync(mainIndexFilePath));
         this._js5ArchiveIndexes = new Map<string, ByteBuffer>();
 
-        for(const fileName of storeFileNames) {
-            if(!fileName?.length || fileName === mainIndexFile || fileName === dataFile) {
+        for (const fileName of storeFileNames) {
+            if (
+                !fileName?.length ||
+                fileName === mainIndexFile ||
+                fileName === dataFile
+            ) {
                 continue;
             }
 
-            if(!fileName.startsWith(indexFilePrefix)) {
+            if (!fileName.startsWith(indexFilePrefix)) {
                 continue;
             }
 
             const index = fileName.substring(fileName.indexOf('.idx') + 4);
             const numericIndex = Number(index);
 
-            if(Number.isNaN(numericIndex)) {
-                logger.error(`Index file ${fileName} does not have a valid extension.`);
+            if (Number.isNaN(numericIndex)) {
+                logger.error(
+                    `Index file ${fileName} does not have a valid extension.`,
+                );
             }
 
-            if(!this.has(index)) {
-                logger.warn(`Archive ${index} was found within the JS5 store, but is not configured for flat file store use.`,
-                    'Please add the archive to the archives.json5 configuration file to load it properly.');
+            if (!this.has(index)) {
+                logger.warn(
+                    `Archive ${index} was found within the JS5 store, but is not configured for flat file store use.`,
+                    'Please add the archive to the archives.json5 configuration file to load it properly.',
+                );
                 continue;
             }
 
-            this._js5ArchiveIndexes.set(index, new ByteBuffer(readFileSync(join(js5StorePath, fileName))));
+            this._js5ArchiveIndexes.set(
+                index,
+                new ByteBuffer(readFileSync(join(js5StorePath, fileName))),
+            );
         }
 
         logger.info(`Packed store loaded for game build ${this.gameBuild}.`);
@@ -207,7 +252,7 @@ export class Store {
     }
 
     public decode(decodeGroups = true): ByteBuffer | null {
-        this.archives.forEach(archive => archive.decode(decodeGroups));
+        this.archives.forEach((archive) => archive.decode(decodeGroups));
         return null;
     }
 
@@ -219,36 +264,44 @@ export class Store {
         this._data.put(0);
         this._data.put(fileSize, 'int');
 
-        for(let archiveIndex = 0; archiveIndex < this.archiveCount; archiveIndex++) {
+        for (
+            let archiveIndex = 0;
+            archiveIndex < this.archiveCount;
+            archiveIndex++
+        ) {
             this._data.put(this.get(archiveIndex).index.crc32, 'int');
         }
 
         this.mainArchive.setData(this._data, FileState.encoded);
-        this.mainArchive.index.data = this.index.data = this._data.toNodeBuffer();
+        this.mainArchive.index.data = this.index.data =
+            this._data.toNodeBuffer();
 
-        if(encodeGroups) {
-            this.archives.forEach(archive => archive.encode(true));
+        if (encodeGroups) {
+            this.archives.forEach((archive) => archive.encode(true));
         }
 
         return this.data;
     }
 
     public compress(compressGroups = true): ByteBuffer | null {
-        this.archives.forEach(archive => archive.compress(compressGroups));
+        this.archives.forEach((archive) => archive.compress(compressGroups));
 
         this._compressed = true;
         return this._data;
     }
 
-    public async read(compress = false, readDiskFiles = true): Promise<ByteBuffer> {
+    public async read(
+        compress = false,
+        readDiskFiles = true,
+    ): Promise<ByteBuffer> {
         this._js5Encoded = false;
         this._compressed = false;
 
-        for(const [ , archive ] of this.archives) {
+        for (const [, archive] of this.archives) {
             await archive.read(false, readDiskFiles);
         }
 
-        if(compress) {
+        if (compress) {
             this.compress();
         }
 
@@ -256,79 +309,90 @@ export class Store {
     }
 
     public write(): void {
-        if(!this.archives.size) {
-            throw new Error('Archives not loaded, please load a flat file store or a JS5 store.');
+        if (!this.archives.size) {
+            throw new Error(
+                'Archives not loaded, please load a flat file store or a JS5 store.',
+            );
         }
 
         const start = Date.now();
         logger.info('Writing flat file store...');
 
         try {
-            if(existsSync(this.outputPath)) {
+            if (existsSync(this.outputPath)) {
                 rmSync(this.outputPath, { recursive: true, force: true });
             }
 
             mkdirSync(this.outputPath, { recursive: true });
-        } catch(error) {
-            logger.error(`Error clearing file store output path (${this.outputPath}):`, error);
+        } catch (error) {
+            logger.error(
+                `Error clearing file store output path (${this.outputPath}):`,
+                error,
+            );
             return;
         }
 
         try {
             logger.info('Writing archive contents to disk...');
-            this.archives.forEach(archive => archive.write());
+            this.archives.forEach((archive) => archive.write());
             logger.info('Archives written.');
-        } catch(error) {
+        } catch (error) {
             logger.error('Error writing archives:', error);
             return;
         }
 
         const end = Date.now();
-        logger.info(`Flat file store written in ${(end - start) / 1000} seconds.`);
+        logger.info(
+            `Flat file store written in ${(end - start) / 1000} seconds.`,
+        );
     }
 
-    public async saveIndexData(saveArchives = true, saveGroups = true, saveFiles = true): Promise<void> {
+    public async saveIndexData(
+        saveArchives = true,
+        saveGroups = true,
+        saveFiles = true,
+    ): Promise<void> {
         try {
             await this.indexService.saveStoreIndex();
             logger.info('File store index saved.');
-        } catch(error) {
+        } catch (error) {
             logger.error('Error indexing file store:', error);
             return;
         }
 
-        if(saveArchives) {
+        if (saveArchives) {
             logger.info('Indexing archives...');
 
-            for(const [ , archive ] of this.archives) {
+            for (const [, archive] of this.archives) {
                 try {
                     await archive.saveIndexData(false);
-                } catch(error) {
+                } catch (error) {
                     logger.error('Error indexing archive:', error);
                     return;
                 }
             }
         }
 
-        if(saveGroups) {
+        if (saveGroups) {
             logger.info('Indexing archive groups...');
 
-            for(const [ , archive ] of this.archives) {
+            for (const [, archive] of this.archives) {
                 try {
                     await archive.saveGroupIndexes(false);
-                } catch(error) {
+                } catch (error) {
                     logger.error('Error indexing group:', error);
                     return;
                 }
             }
         }
 
-        if(saveFiles) {
+        if (saveFiles) {
             logger.info('Indexing archive files...');
 
-            for(const [ , archive ] of this.archives) {
+            for (const [, archive] of this.archives) {
                 try {
                     await archive.saveFlatFileIndexes();
-                } catch(error) {
+                } catch (error) {
                     logger.error('Error indexing flat file:', error);
                     return;
                 }
@@ -337,7 +401,11 @@ export class Store {
     }
 
     public find(archiveName: string): Archive {
-        return Array.from(this.archives.values()).find(child => child?.name === archiveName) ?? null;
+        return (
+            Array.from(this.archives.values()).find(
+                (child) => child?.name === archiveName,
+            ) ?? null
+        );
     }
 
     public get(archiveKey: string): Archive | null;
@@ -360,30 +428,37 @@ export class Store {
 
     public loadArchiveConfig(): void {
         const configPath = join(this.path, 'config', 'archives.json5');
-        if(!existsSync(configPath)) {
+        if (!existsSync(configPath)) {
             logger.error(`Error loading store: ${configPath} was not found.`);
             return;
         }
 
-        this._archiveConfig = JSON5.parse(readFileSync(configPath, 'utf-8')) as { [key: string]: ArchiveConfig };
+        this._archiveConfig = JSON5.parse(
+            readFileSync(configPath, 'utf-8'),
+        ) as { [key: string]: ArchiveConfig };
 
-        if(!Object.values(this._archiveConfig)?.length) {
-            throw new Error(`Error reading archive configuration file. Please ensure that the ${configPath} file exists and is valid.`);
+        if (!Object.values(this._archiveConfig)?.length) {
+            throw new Error(
+                `Error reading archive configuration file. Please ensure that the ${configPath} file exists and is valid.`,
+            );
         }
     }
 
     public getEncryptionKeys(fileName: string): XteaKeys | XteaKeys[] | null {
-        if(!this.encryptionKeys.size) {
+        if (!this.encryptionKeys.size) {
             this.loadEncryptionKeys();
         }
 
         const keySets = this.encryptionKeys.get(fileName);
-        if(!keySets) {
+        if (!keySets) {
             return null;
         }
 
-        if(this.gameBuild !== undefined) {
-            return keySets.find(keySet => keySet.gameBuild === this.gameBuild) ?? null;
+        if (this.gameBuild !== undefined) {
+            return (
+                keySets.find((keySet) => keySet.gameBuild === this.gameBuild) ??
+                null
+            );
         }
 
         return keySets;
@@ -393,39 +468,44 @@ export class Store {
         const configPath = join(this.path, 'config', 'xtea');
         this._encryptionKeys = Xtea.loadKeys(configPath);
 
-        if(!this.encryptionKeys.size) {
-            throw new Error(`Error reading encryption key lookup table. Please ensure that the ${configPath} file exists and is valid.`);
+        if (!this.encryptionKeys.size) {
+            throw new Error(
+                `Error reading encryption key lookup table. Please ensure that the ${configPath} file exists and is valid.`,
+            );
         }
     }
 
     public hashFileName(fileName: string): number {
-        if(!fileName) {
+        if (!fileName) {
             return 0;
         }
 
         let hash = 0;
-        for(let i = 0; i < fileName.length; i++) {
+        for (let i = 0; i < fileName.length; i++) {
             hash = fileName.charCodeAt(i) + ((hash << 5) - hash);
         }
 
         return hash | 0;
     }
 
-    public findFileName(nameHash: string | number | undefined, defaultName?: string | undefined): string | undefined {
-        if(!this.fileNameHashes.size) {
+    public findFileName(
+        nameHash: string | number | undefined,
+        defaultName?: string | undefined,
+    ): string | undefined {
+        if (!this.fileNameHashes.size) {
             this.loadFileNames();
         }
 
-        if(nameHash === undefined || nameHash === null) {
+        if (nameHash === undefined || nameHash === null) {
             return defaultName;
         }
 
-        if(typeof nameHash === 'string') {
+        if (typeof nameHash === 'string') {
             // biome-ignore lint/style/noParameterAssign: Legacy
             nameHash = Number(nameHash);
         }
 
-        if(Number.isNaN(nameHash) || nameHash === -1 || nameHash === 0) {
+        if (Number.isNaN(nameHash) || nameHash === -1 || nameHash === 0) {
             return defaultName;
         }
 
@@ -434,16 +514,24 @@ export class Store {
 
     public loadFileNames(): void {
         const configPath = join(this.path, 'config', 'name-hashes.json');
-        if(!existsSync(configPath)) {
-            logger.error(`Error loading file names: ${configPath} was not found.`);
+        if (!existsSync(configPath)) {
+            logger.error(
+                `Error loading file names: ${configPath} was not found.`,
+            );
             return;
         }
 
-        const nameTable = JSON.parse(readFileSync(configPath, 'utf-8')) as { [key: string]: string };
-        Object.keys(nameTable).forEach(nameHash => this.fileNameHashes.set(Number(nameHash), nameTable[nameHash]));
+        const nameTable = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+            [key: string]: string;
+        };
+        Object.keys(nameTable).forEach((nameHash) =>
+            this.fileNameHashes.set(Number(nameHash), nameTable[nameHash]),
+        );
 
-        if(!this.fileNameHashes.size) {
-            throw new Error(`Error reading file name lookup table. Please ensure that the ${configPath} file exists and is valid.`);
+        if (!this.fileNameHashes.size) {
+            throw new Error(
+                `Error reading file name lookup table. Please ensure that the ${configPath} file exists and is valid.`,
+            );
         }
     }
 
@@ -456,7 +544,7 @@ export class Store {
     }
 
     public get js5MainIndex(): ByteBuffer {
-        if(!this._js5MainIndex?.length || !this._js5MainArchiveData?.length) {
+        if (!this._js5MainIndex?.length || !this._js5MainArchiveData?.length) {
             this.decode();
         }
 
@@ -464,7 +552,7 @@ export class Store {
     }
 
     public get js5ArchiveIndexes(): Map<string, ByteBuffer> {
-        if(!this._js5MainIndex?.length || !this._js5MainArchiveData?.length) {
+        if (!this._js5MainIndex?.length || !this._js5MainArchiveData?.length) {
             this.decode();
         }
 
@@ -472,7 +560,7 @@ export class Store {
     }
 
     public get js5MainArchiveData(): ByteBuffer {
-        if(!this._js5MainIndex?.length || !this._js5MainArchiveData?.length) {
+        if (!this._js5MainIndex?.length || !this._js5MainArchiveData?.length) {
             this.decode();
         }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,13 +1,13 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'graceful-fs';
-import { join } from 'path';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import JSON5 from 'json5';
 import { ByteBuffer, logger } from '@runejs/common';
-import { Xtea, XteaKeys } from '@runejs/common/encrypt';
+import { Xtea, type XteaKeys } from '@runejs/common/encrypt';
 import { Crc32 } from '@runejs/common/crc32';
 
 import { Archive, FileState } from './index';
 import { ArchiveIndexEntity, IndexService, StoreIndexEntity } from './db';
-import { ArchiveConfig } from './config';
+import type { ArchiveConfig } from './config';
 
 
 export type StoreFormat = 'unpacked' | 'packed';
@@ -30,8 +30,8 @@ export class Store {
     private _index: StoreIndexEntity;
     private _mainArchive: Archive;
     private _data: ByteBuffer;
-    private _compressed: boolean = false;
-    private _js5Encoded: boolean = false;
+    private _compressed = false;
+    private _js5Encoded = false;
     private _path: string;
     private _outputPath: string;
     private _archiveConfig: { [key: string]: ArchiveConfig };
@@ -48,7 +48,7 @@ export class Store {
         Crc32.init();
     }
 
-    public static async create(gameBuild: string, path: string = './', options?: StoreOptions): Promise<Store> {
+    public static async create(gameBuild: string, path = './', options?: StoreOptions): Promise<Store> {
         const store = new Store(gameBuild, path, options?.outputPath);
 
         await store.indexService.load();
@@ -69,8 +69,8 @@ export class Store {
         const mainArchiveConfig = Array.from(Object.values(store.archiveConfig)).find(a => a.index === 255);
 
         if(!mainArchiveConfig) {
-            throw new Error(`Main archive (index 255) configuration was not found. ` +
-                `Please configure the main archive using the archives.json5 file within the store config directory.`)
+            throw new Error('Main archive (index 255) configuration was not found. ' +
+                'Please configure the main archive using the archives.json5 file within the store config directory.')
         }
 
         const mainArchiveIndex = new ArchiveIndexEntity();
@@ -120,7 +120,8 @@ export class Store {
             store.archives.set(archive.key, archive);
 
             // Bulk-fetch the archive's groups
-            const groups = archiveIndex.groups = await store.indexService.getGroupIndexes(archiveIndex);
+            // biome-ignore lint/suspicious/noAssignInExpressions: Legacy
+                        const groups = archiveIndex.groups = await store.indexService.getGroupIndexes(archiveIndex);
 
             // Bulk-fetch the archive's files and sort them into the appropriate groups
             const archiveFileIndexes = await store.indexService.getFileIndexes(archiveIndex);
@@ -185,13 +186,13 @@ export class Store {
             const index = fileName.substring(fileName.indexOf('.idx') + 4);
             const numericIndex = Number(index);
 
-            if(isNaN(numericIndex)) {
+            if(Number.isNaN(numericIndex)) {
                 logger.error(`Index file ${fileName} does not have a valid extension.`);
             }
 
             if(!this.has(index)) {
                 logger.warn(`Archive ${index} was found within the JS5 store, but is not configured for flat file store use.`,
-                    `Please add the archive to the archives.json5 configuration file to load it properly.`);
+                    'Please add the archive to the archives.json5 configuration file to load it properly.');
                 continue;
             }
 
@@ -205,12 +206,12 @@ export class Store {
         // @TODO
     }
 
-    public decode(decodeGroups: boolean = true): ByteBuffer | null {
+    public decode(decodeGroups = true): ByteBuffer | null {
         this.archives.forEach(archive => archive.decode(decodeGroups));
         return null;
     }
 
-    public encode(encodeGroups: boolean = true): ByteBuffer {
+    public encode(encodeGroups = true): ByteBuffer {
         const fileSize = 4 * this.archiveCount;
 
         this._data = new ByteBuffer(fileSize + 31);
@@ -232,14 +233,14 @@ export class Store {
         return this.data;
     }
 
-    public compress(compressGroups: boolean = true): ByteBuffer | null {
+    public compress(compressGroups = true): ByteBuffer | null {
         this.archives.forEach(archive => archive.compress(compressGroups));
 
         this._compressed = true;
         return this._data;
     }
 
-    public async read(compress: boolean = false, readDiskFiles: boolean = true): Promise<ByteBuffer> {
+    public async read(compress = false, readDiskFiles = true): Promise<ByteBuffer> {
         this._js5Encoded = false;
         this._compressed = false;
 
@@ -256,11 +257,11 @@ export class Store {
 
     public write(): void {
         if(!this.archives.size) {
-            throw new Error(`Archives not loaded, please load a flat file store or a JS5 store.`);
+            throw new Error('Archives not loaded, please load a flat file store or a JS5 store.');
         }
 
         const start = Date.now();
-        logger.info(`Writing flat file store...`);
+        logger.info('Writing flat file store...');
 
         try {
             if(existsSync(this.outputPath)) {
@@ -274,11 +275,11 @@ export class Store {
         }
 
         try {
-            logger.info(`Writing archive contents to disk...`);
+            logger.info('Writing archive contents to disk...');
             this.archives.forEach(archive => archive.write());
-            logger.info(`Archives written.`);
+            logger.info('Archives written.');
         } catch(error) {
-            logger.error(`Error writing archives:`, error);
+            logger.error('Error writing archives:', error);
             return;
         }
 
@@ -286,49 +287,49 @@ export class Store {
         logger.info(`Flat file store written in ${(end - start) / 1000} seconds.`);
     }
 
-    public async saveIndexData(saveArchives: boolean = true, saveGroups: boolean = true, saveFiles: boolean = true): Promise<void> {
+    public async saveIndexData(saveArchives = true, saveGroups = true, saveFiles = true): Promise<void> {
         try {
             await this.indexService.saveStoreIndex();
-            logger.info(`File store index saved.`);
+            logger.info('File store index saved.');
         } catch(error) {
-            logger.error(`Error indexing file store:`, error);
+            logger.error('Error indexing file store:', error);
             return;
         }
 
         if(saveArchives) {
-            logger.info(`Indexing archives...`);
+            logger.info('Indexing archives...');
 
             for(const [ , archive ] of this.archives) {
                 try {
                     await archive.saveIndexData(false);
                 } catch(error) {
-                    logger.error(`Error indexing archive:`, error);
+                    logger.error('Error indexing archive:', error);
                     return;
                 }
             }
         }
 
         if(saveGroups) {
-            logger.info(`Indexing archive groups...`);
+            logger.info('Indexing archive groups...');
 
             for(const [ , archive ] of this.archives) {
                 try {
                     await archive.saveGroupIndexes(false);
                 } catch(error) {
-                    logger.error(`Error indexing group:`, error);
+                    logger.error('Error indexing group:', error);
                     return;
                 }
             }
         }
 
         if(saveFiles) {
-            logger.info(`Indexing archive files...`);
+            logger.info('Indexing archive files...');
 
             for(const [ , archive ] of this.archives) {
                 try {
                     await archive.saveFlatFileIndexes();
                 } catch(error) {
-                    logger.error(`Error indexing flat file:`, error);
+                    logger.error('Error indexing flat file:', error);
                     return;
                 }
             }
@@ -367,8 +368,7 @@ export class Store {
         this._archiveConfig = JSON5.parse(readFileSync(configPath, 'utf-8')) as { [key: string]: ArchiveConfig };
 
         if(!Object.values(this._archiveConfig)?.length) {
-            throw new Error(`Error reading archive configuration file. ` +
-                `Please ensure that the ${configPath} file exists and is valid.`);
+            throw new Error(`Error reading archive configuration file. Please ensure that the ${configPath} file exists and is valid.`);
         }
     }
 
@@ -394,8 +394,7 @@ export class Store {
         this._encryptionKeys = Xtea.loadKeys(configPath);
 
         if(!this.encryptionKeys.size) {
-            throw new Error(`Error reading encryption key lookup table. ` +
-                `Please ensure that the ${configPath} file exists and is valid.`);
+            throw new Error(`Error reading encryption key lookup table. Please ensure that the ${configPath} file exists and is valid.`);
         }
     }
 
@@ -422,10 +421,11 @@ export class Store {
         }
 
         if(typeof nameHash === 'string') {
+            // biome-ignore lint/style/noParameterAssign: Legacy
             nameHash = Number(nameHash);
         }
 
-        if(isNaN(nameHash) || nameHash === -1 || nameHash === 0) {
+        if(Number.isNaN(nameHash) || nameHash === -1 || nameHash === 0) {
             return defaultName;
         }
 
@@ -443,8 +443,7 @@ export class Store {
         Object.keys(nameTable).forEach(nameHash => this.fileNameHashes.set(Number(nameHash), nameTable[nameHash]));
 
         if(!this.fileNameHashes.size) {
-            throw new Error(`Error reading file name lookup table. ` +
-                `Please ensure that the ${configPath} file exists and is valid.`);
+            throw new Error(`Error reading file name lookup table. Please ensure that the ${configPath} file exists and is valid.`);
         }
     }
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,2 +1,2 @@
-export const isSet = (variable: any): boolean =>
+export const isSet = (variable: unknown): boolean =>
     variable !== undefined && variable !== null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,8 @@
         "allowJs": true,
         "declaration": true,
         "outDir": "./lib",
-        "types": [
-            "node"
-        ]
+        "types": ["node"]
     },
-    "include": [ "src/" ],
-    "exclude": [ "!src/" ]
+    "include": ["src/"],
+    "exclude": ["!src/"]
 }


### PR DESCRIPTION
Removes the ESLint package and project and replaces it with Biome to handle both formatting and linting.

I've modified the Biome config to use single quotes and 4 space indentation so as to minimise noise in the diff.

I tidied up the dependencies as they were quite outdated and several of them had been abandoned (mostly due to Node adopting or surpassing the functionality in modern releases).

Each of the commands runs after adding the 435 assets required - although not without some errors (not sure if that's expected / I missed some files - or - I broke something, hopefully not).

The TypeORM package needs to be updated to the latest >0.3 due to a number of security vulnerabilities. There is a breaking API change I'm not entirely sure how to resolve. You can read about it [here](https://github.com/typeorm/typeorm/releases/tag/0.3.0) (search for `you must explicitly define a column marked as primary`).

Better-sqlite3 was a real PITA - not supporting Apple Silicon on any version officially supported by TypeORM - for this reason I had to add `legacy-peer-deps=true` to enable `npm install` to run with the latest version of the package. As far as I can tell - this works fine.